### PR TITLE
I/O stats, history recording with Top Consumers view, find open file (#11, #9, #7)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,6 +280,7 @@ if(BUILD_TUI AND NCURSES_FOUND)
         src/ui/tui/tui_details_panel.cpp
         src/ui/tui/tui_details_tabs.cpp
         src/ui/tui/tui_kill_dialog.cpp
+        src/ui/tui/tui_find_file.cpp
         src/ui/tui/tui_input.cpp
         src/ui/tui/tui_input_panels.cpp
         src/ui/tui/tui_colors.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,7 @@ if(BUILD_GUI)
         src/ui/imgui/imgui_process_popup_view.cpp
         src/ui/imgui/imgui_kill_dialog_view.cpp
         src/ui/imgui/imgui_find_handle_dialog.cpp
+        src/ui/imgui/imgui_history_view.cpp
         src/ui/imgui/imgui_input.cpp
     )
     target_include_directories(pex_ui_imgui PUBLIC src PRIVATE ${stb_SOURCE_DIR} ${CMAKE_BINARY_DIR}/generated)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ endif()
 # =============================================================================
 add_library(pex_core STATIC
     src/core/services/data_store.cpp
+    src/core/services/history_store.cpp
     src/core/services/name_resolver.cpp
     src/core/services/single_instance.cpp
     src/core/model/system_info.cpp
@@ -188,6 +189,7 @@ if(BUILD_GUI)
         src/ui/imgui/imgui_details_tabs.cpp
         src/ui/imgui/imgui_process_popup_view.cpp
         src/ui/imgui/imgui_kill_dialog_view.cpp
+        src/ui/imgui/imgui_find_handle_dialog.cpp
         src/ui/imgui/imgui_input.cpp
     )
     target_include_directories(pex_ui_imgui PUBLIC src PRIVATE ${stb_SOURCE_DIR} ${CMAKE_BINARY_DIR}/generated)

--- a/src/core/model/process_info.hpp
+++ b/src/core/model/process_info.hpp
@@ -29,6 +29,8 @@ struct ProcessInfo {
     // CPU usage (calculated by DataStore)
     double cpu_percent = 0.0;        // Per-core (100% = 1 core)
     double total_cpu_percent = 0.0;  // Overall (100% = all cores)
+    double cpu_user_percent = 0.0;   // User-mode share of all cores (sums with kernel to total_cpu_percent)
+    double cpu_kernel_percent = 0.0; // Kernel-mode share of all cores
 
     // Memory (in bytes)
     int64_t resident_memory = 0;     // Working set / RSS
@@ -44,6 +46,15 @@ struct ProcessInfo {
     // These are cumulative counters - only the delta between snapshots is meaningful
     uint64_t user_time = 0;
     uint64_t kernel_time = 0;
+
+    // Cumulative storage I/O counters in bytes (Linux: /proc/<pid>/io
+    // read_bytes/write_bytes). 0 = unavailable on this platform.
+    uint64_t io_read_bytes = 0;
+    uint64_t io_write_bytes = 0;
+
+    // I/O rates in bytes/sec (calculated by DataStore from counter deltas)
+    double io_read_rate = 0.0;
+    double io_write_rate = 0.0;
 };
 
 struct ThreadInfo {

--- a/src/core/services/data_store.cpp
+++ b/src/core/services/data_store.cpp
@@ -1,4 +1,5 @@
 #include "data_store.hpp"
+#include "history_store.hpp"
 #include <algorithm>
 #include <ranges>
 #include <set>
@@ -96,6 +97,10 @@ void DataStore::set_on_data_updated(std::function<void()> callback) {
     on_data_updated_ = std::move(callback);
 }
 
+void DataStore::set_history_store(HistoryStore* history) {
+    history_store_ = history;
+}
+
 std::vector<ParseError> DataStore::get_recent_errors() const {
     return process_provider_->get_recent_errors();
 }
@@ -143,31 +148,48 @@ void DataStore::collect_data() {
     // Get all processes
     auto processes = process_provider_->get_all_processes(mem_info.total);
 
-    // Calculate CPU percentages and collect current PIDs
+    // Wall-clock seconds since the previous tick (for I/O rate calculation)
+    const double elapsed_sec = (previous_snapshot_time_.time_since_epoch().count() != 0)
+        ? std::chrono::duration<double>(new_snapshot->timestamp - previous_snapshot_time_).count()
+        : 0.0;
+    previous_snapshot_time_ = new_snapshot->timestamp;
+
+    // Calculate CPU percentages / I/O rates and collect current PIDs
     std::set<int> current_pids;
     unsigned int proc_count = system_provider_->get_processor_count();
     for (auto& proc : processes) {
         current_pids.insert(proc.pid);
-        if (auto it = previous_cpu_times_.find(proc.pid); it != previous_cpu_times_.end()) {
-            const auto [prev_user, prev_kernel] = it->second;
-            const bool counters_valid = proc.user_time >= prev_user && proc.kernel_time >= prev_kernel;
+        if (auto it = previous_proc_counters_.find(proc.pid); it != previous_proc_counters_.end()) {
+            const ProcCounters& prev = it->second;
+            const bool counters_valid = proc.user_time >= prev.user_time && proc.kernel_time >= prev.kernel_time;
             if (counters_valid && total_cpu_delta > 0) {
-                const uint64_t user_delta = proc.user_time - prev_user;
-                const uint64_t kernel_delta = proc.kernel_time - prev_kernel;
+                const uint64_t user_delta = proc.user_time - prev.user_time;
+                const uint64_t kernel_delta = proc.kernel_time - prev.kernel_time;
                 const uint64_t process_delta = user_delta + kernel_delta;
                 proc.cpu_percent = static_cast<double>(process_delta) / total_cpu_delta * 100.0 * proc_count;
                 proc.total_cpu_percent = static_cast<double>(process_delta) / total_cpu_delta * 100.0;
+                proc.cpu_user_percent = static_cast<double>(user_delta) / total_cpu_delta * 100.0;
+                proc.cpu_kernel_percent = static_cast<double>(kernel_delta) / total_cpu_delta * 100.0;
             } else {
                 // PID reused or counters wrapped – reset baseline
                 proc.cpu_percent = 0.0;
                 proc.total_cpu_percent = 0.0;
             }
+            // I/O rates: same PID-reuse guard (counters are monotonic per process)
+            const bool io_valid = counters_valid &&
+                proc.io_read_bytes >= prev.io_read_bytes &&
+                proc.io_write_bytes >= prev.io_write_bytes;
+            if (io_valid && elapsed_sec > 0.0) {
+                proc.io_read_rate = static_cast<double>(proc.io_read_bytes - prev.io_read_bytes) / elapsed_sec;
+                proc.io_write_rate = static_cast<double>(proc.io_write_bytes - prev.io_write_bytes) / elapsed_sec;
+            }
         }
-        previous_cpu_times_[proc.pid] = {proc.user_time, proc.kernel_time};
+        previous_proc_counters_[proc.pid] = {proc.user_time, proc.kernel_time,
+                                             proc.io_read_bytes, proc.io_write_bytes};
     }
 
     // Prune stale entries for processes that no longer exist
-    std::erase_if(previous_cpu_times_, [&current_pids](const auto& entry) {
+    std::erase_if(previous_proc_counters_, [&current_pids](const auto& entry) {
         return !current_pids.contains(entry.first);
     });
 
@@ -310,6 +332,11 @@ void DataStore::collect_data() {
 
     // Update previous values
     previous_system_cpu_times_ = current_cpu_times;
+
+    // Record into history before publishing (snapshot is fully built here)
+    if (HistoryStore* history = history_store_.load()) {
+        history->record(*new_snapshot);
+    }
 
     // Atomically swap the snapshot
     std::function<void()> callback;

--- a/src/core/services/data_store.hpp
+++ b/src/core/services/data_store.hpp
@@ -16,6 +16,8 @@
 
 namespace pex {
 
+class HistoryStore;
+
 struct ProcessNode {
     ProcessInfo info;
     std::vector<std::unique_ptr<ProcessNode>> children;
@@ -103,6 +105,10 @@ public:
     // Get recent parse errors for status bar display
     [[nodiscard]] std::vector<ParseError> get_recent_errors() const;
 
+    // Optional history recorder; every collected snapshot is recorded into it.
+    // LIFETIME: must outlive this DataStore (or be detached with nullptr first).
+    void set_history_store(HistoryStore* history);
+
 private:
     void collection_thread_func();
     void collect_data();
@@ -112,6 +118,7 @@ private:
     // Injected providers (owned externally)
     IProcessDataProvider* process_provider_;
     ISystemDataProvider* system_provider_;
+    std::atomic<HistoryStore*> history_store_{nullptr};
 
     // Background thread
     std::thread collection_thread_;
@@ -127,14 +134,23 @@ private:
     mutable std::mutex data_mutex_;
     std::shared_ptr<DataSnapshot> current_snapshot_;
 
-    // For CPU delta calculations (pre-allocated, reused each tick)
+    // For CPU/IO delta calculations (pre-allocated, reused each tick)
     CpuTimes previous_system_cpu_times_;
     std::vector<CpuTimes> previous_per_cpu_times_;
     std::vector<CpuTimes> current_per_cpu_times_;  // Reused buffer
     std::vector<double> per_cpu_usage_buffer_;     // Reused buffer
     std::vector<double> per_cpu_user_buffer_;      // Reused buffer
     std::vector<double> per_cpu_system_buffer_;    // Reused buffer
-    std::unordered_map<int, std::pair<uint64_t, uint64_t>> previous_cpu_times_;
+
+    // Per-process cumulative counters from the previous tick
+    struct ProcCounters {
+        uint64_t user_time = 0;
+        uint64_t kernel_time = 0;
+        uint64_t io_read_bytes = 0;
+        uint64_t io_write_bytes = 0;
+    };
+    std::unordered_map<int, ProcCounters> previous_proc_counters_;
+    std::chrono::steady_clock::time_point previous_snapshot_time_{};
 
     // Callback
     std::function<void()> on_data_updated_;

--- a/src/core/services/history_store.cpp
+++ b/src/core/services/history_store.cpp
@@ -1,0 +1,172 @@
+#include "history_store.hpp"
+#include "data_store.hpp"
+
+#include <algorithm>
+#include <format>
+#include <fstream>
+
+namespace pex {
+
+HistoryStore::HistoryStore(const size_t max_samples)
+    : max_samples_(max_samples == 0 ? 1 : max_samples) {}
+
+void HistoryStore::record(const DataSnapshot& snapshot) {
+    HistorySample sample;
+    sample.wall_time = std::chrono::system_clock::now();
+    sample.cpu_usage = static_cast<float>(snapshot.cpu_usage);
+    sample.memory_used = snapshot.memory_used;
+    sample.memory_total = snapshot.memory_total;
+    sample.process_count = snapshot.process_count;
+    sample.thread_count = snapshot.thread_count;
+
+    sample.per_cpu_user.reserve(snapshot.per_cpu_user.size());
+    for (double v : snapshot.per_cpu_user) sample.per_cpu_user.push_back(static_cast<float>(v));
+    sample.per_cpu_system.reserve(snapshot.per_cpu_system.size());
+    for (double v : snapshot.per_cpu_system) sample.per_cpu_system.push_back(static_cast<float>(v));
+
+    sample.processes.reserve(snapshot.process_map.size());
+
+    std::lock_guard lock(mutex_);
+    for (const auto& [pid, node] : snapshot.process_map) {
+        const ProcessInfo& info = node->info;
+        ProcessSample ps;
+        ps.pid = pid;
+        ps.cpu_user_percent = static_cast<float>(info.cpu_user_percent);
+        ps.cpu_kernel_percent = static_cast<float>(info.cpu_kernel_percent);
+        ps.memory_percent = static_cast<float>(info.memory_percent);
+        ps.resident_memory = info.resident_memory;
+        ps.io_read_rate = static_cast<float>(info.io_read_rate);
+        ps.io_write_rate = static_cast<float>(info.io_write_rate);
+        sample.processes.push_back(ps);
+
+        process_names_[pid] = info.name;
+    }
+
+    samples_.push_back(std::move(sample));
+    while (samples_.size() > max_samples_) {
+        samples_.pop_front();
+    }
+
+    // Bound the name map: drop names for PIDs no longer present in any
+    // retained sample (cheap approximation: prune when it grows large).
+    if (process_names_.size() > 4 * samples_.back().processes.size() + 1024) {
+        std::unordered_map<int, std::string> kept;
+        for (const auto& s : samples_) {
+            for (const auto& ps : s.processes) {
+                if (auto it = process_names_.find(ps.pid); it != process_names_.end()) {
+                    kept[ps.pid] = it->second;
+                }
+            }
+        }
+        process_names_ = std::move(kept);
+    }
+}
+
+size_t HistoryStore::sample_count() const {
+    std::lock_guard lock(mutex_);
+    return samples_.size();
+}
+
+ProcessHistorySeries HistoryStore::get_series(const std::vector<int>& pids,
+                                              const size_t max_points) const {
+    ProcessHistorySeries series;
+
+    std::lock_guard lock(mutex_);
+    const size_t count = std::min(samples_.size(), max_points);
+    if (count == 0) return series;
+
+    series.cpu_user.reserve(count);
+    series.cpu_kernel.reserve(count);
+    series.memory_percent.reserve(count);
+
+    const size_t first = samples_.size() - count;
+    const size_t cpu_count = samples_.back().per_cpu_user.size();
+    series.per_cpu_user.assign(cpu_count, {});
+    series.per_cpu_kernel.assign(cpu_count, {});
+    for (auto& v : series.per_cpu_user) v.reserve(count);
+    for (auto& v : series.per_cpu_kernel) v.reserve(count);
+
+    for (size_t i = first; i < samples_.size(); i++) {
+        const HistorySample& s = samples_[i];
+
+        float user = 0.0f, kernel = 0.0f, mem = 0.0f;
+        for (const ProcessSample& ps : s.processes) {
+            if (std::find(pids.begin(), pids.end(), ps.pid) != pids.end()) {
+                user += ps.cpu_user_percent;
+                kernel += ps.cpu_kernel_percent;
+                mem += ps.memory_percent;
+            }
+        }
+        series.cpu_user.push_back(user);
+        series.cpu_kernel.push_back(kernel);
+        series.memory_percent.push_back(mem);
+
+        for (size_t c = 0; c < cpu_count; c++) {
+            series.per_cpu_user[c].push_back(c < s.per_cpu_user.size() ? s.per_cpu_user[c] : 0.0f);
+            series.per_cpu_kernel[c].push_back(c < s.per_cpu_system.size() ? s.per_cpu_system[c] : 0.0f);
+        }
+    }
+
+    return series;
+}
+
+static std::string format_wall_time(const std::chrono::system_clock::time_point tp) {
+    const auto time = std::chrono::system_clock::to_time_t(tp);
+    std::tm tm_val{};
+    localtime_r(&time, &tm_val);
+    const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+        tp.time_since_epoch()).count() % 1000;
+    return std::format("{:04}-{:02}-{:02} {:02}:{:02}:{:02}.{:03}",
+                       tm_val.tm_year + 1900, tm_val.tm_mon + 1, tm_val.tm_mday,
+                       tm_val.tm_hour, tm_val.tm_min, tm_val.tm_sec, ms);
+}
+
+bool HistoryStore::export_csv(const std::string& base_path, std::string& error) const {
+    const std::string system_path = base_path + "-system.csv";
+    const std::string process_path = base_path + "-processes.csv";
+
+    std::ofstream sys_file(system_path);
+    std::ofstream proc_file(process_path);
+    if (!sys_file || !proc_file) {
+        error = "Cannot create " + (!sys_file ? system_path : process_path);
+        return false;
+    }
+
+    sys_file << "time,cpu_usage_pct,memory_used_bytes,memory_total_bytes,process_count,thread_count\n";
+    proc_file << "time,pid,name,cpu_user_pct,cpu_kernel_pct,mem_pct,rss_bytes,io_read_bps,io_write_bps\n";
+
+    std::lock_guard lock(mutex_);
+    for (const HistorySample& s : samples_) {
+        const std::string ts = format_wall_time(s.wall_time);
+
+        sys_file << ts << ',' << s.cpu_usage << ',' << s.memory_used << ','
+                 << s.memory_total << ',' << s.process_count << ',' << s.thread_count << '\n';
+
+        for (const ProcessSample& ps : s.processes) {
+            std::string name;
+            if (const auto it = process_names_.find(ps.pid); it != process_names_.end()) {
+                name = it->second;
+            }
+            // CSV-quote the name (it may contain commas/quotes)
+            std::string quoted = "\"";
+            for (char ch : name) {
+                if (ch == '"') quoted += '"';
+                quoted += ch;
+            }
+            quoted += '"';
+
+            proc_file << ts << ',' << ps.pid << ',' << quoted << ','
+                      << ps.cpu_user_percent << ',' << ps.cpu_kernel_percent << ','
+                      << ps.memory_percent << ',' << ps.resident_memory << ','
+                      << ps.io_read_rate << ',' << ps.io_write_rate << '\n';
+        }
+    }
+
+    if (!sys_file.good() || !proc_file.good()) {
+        error = "Write failed (disk full?)";
+        return false;
+    }
+    return true;
+}
+
+} // namespace pex

--- a/src/core/services/history_store.cpp
+++ b/src/core/services/history_store.cpp
@@ -110,6 +110,76 @@ ProcessHistorySeries HistoryStore::get_series(const std::vector<int>& pids,
     return series;
 }
 
+std::vector<ProcessAggregate> HistoryStore::aggregate(const size_t max_samples) const {
+    std::lock_guard lock(mutex_);
+
+    const size_t count = std::min(samples_.size(), max_samples);
+    if (count == 0) return {};
+    const size_t first = samples_.size() - count;
+
+    std::unordered_map<int, ProcessAggregate> by_pid;
+
+    for (size_t i = first; i < samples_.size(); i++) {
+        for (const ProcessSample& ps : samples_[i].processes) {
+            ProcessAggregate& agg = by_pid[ps.pid];
+            agg.pid = ps.pid;
+            agg.present_ticks++;
+
+            const float cpu = ps.cpu_user_percent + ps.cpu_kernel_percent;
+            agg.avg_cpu += cpu;  // Sums for now; divided below
+            agg.peak_cpu = std::max(agg.peak_cpu, cpu);
+            agg.avg_mem += ps.memory_percent;
+            agg.peak_mem = std::max(agg.peak_mem, ps.memory_percent);
+            agg.avg_io_read += ps.io_read_rate;
+            agg.peak_io_read = std::max(agg.peak_io_read, ps.io_read_rate);
+            agg.avg_io_write += ps.io_write_rate;
+            agg.peak_io_write = std::max(agg.peak_io_write, ps.io_write_rate);
+        }
+    }
+
+    std::vector<ProcessAggregate> result;
+    result.reserve(by_pid.size());
+    const auto window = static_cast<float>(count);
+    for (auto& [pid, agg] : by_pid) {
+        agg.avg_cpu /= window;
+        agg.avg_mem /= window;
+        agg.avg_io_read /= window;
+        agg.avg_io_write /= window;
+        if (const auto it = process_names_.find(pid); it != process_names_.end()) {
+            agg.name = it->second;
+        }
+        result.push_back(std::move(agg));
+    }
+    return result;
+}
+
+std::vector<float> HistoryStore::get_metric_series(const int pid, const HistoryMetric metric,
+                                                   const size_t max_points) const {
+    std::lock_guard lock(mutex_);
+
+    const size_t count = std::min(samples_.size(), max_points);
+    std::vector<float> series;
+    series.reserve(count);
+    if (count == 0) return series;
+    const size_t first = samples_.size() - count;
+
+    for (size_t i = first; i < samples_.size(); i++) {
+        float value = 0.0f;
+        for (const ProcessSample& ps : samples_[i].processes) {
+            if (ps.pid != pid) continue;
+            switch (metric) {
+                case HistoryMetric::Cpu:     value = ps.cpu_user_percent + ps.cpu_kernel_percent; break;
+                case HistoryMetric::Memory:  value = ps.memory_percent; break;
+                case HistoryMetric::IoRead:  value = ps.io_read_rate; break;
+                case HistoryMetric::IoWrite: value = ps.io_write_rate; break;
+            }
+            break;
+        }
+        series.push_back(value);
+    }
+    return series;
+}
+
 static std::string format_wall_time(const std::chrono::system_clock::time_point tp) {
     const auto time = std::chrono::system_clock::to_time_t(tp);
     std::tm tm_val{};

--- a/src/core/services/history_store.hpp
+++ b/src/core/services/history_store.hpp
@@ -46,6 +46,29 @@ struct ProcessHistorySeries {
     std::vector<std::vector<float>> per_cpu_kernel;  // [cpu][tick] system-wide
 };
 
+// Metric selector for aggregation/series queries
+enum class HistoryMetric {
+    Cpu,      // user+kernel, % of all cores
+    Memory,   // % of total memory
+    IoRead,   // bytes/sec
+    IoWrite   // bytes/sec
+};
+
+// Per-process aggregate over a window of ticks ("top consumers", issue #9)
+struct ProcessAggregate {
+    int pid = 0;
+    std::string name;       // Last-known process name
+    float avg_cpu = 0.0f;   // Averaged over the whole window (absent ticks = 0)
+    float peak_cpu = 0.0f;
+    float avg_mem = 0.0f;
+    float peak_mem = 0.0f;
+    float avg_io_read = 0.0f;
+    float peak_io_read = 0.0f;
+    float avg_io_write = 0.0f;
+    float peak_io_write = 0.0f;
+    size_t present_ticks = 0;  // Ticks in the window where the PID existed
+};
+
 // Ring buffer of system + per-process samples (issue #9).
 // record() is called from the DataStore collection thread; all query and
 // export methods are safe to call concurrently from the UI thread.
@@ -62,6 +85,16 @@ public:
     // max_points ticks. Ticks where none of the PIDs existed contribute 0.
     [[nodiscard]] ProcessHistorySeries get_series(const std::vector<int>& pids,
                                                   size_t max_points) const;
+
+    // Per-process aggregates over the most recent max_samples ticks.
+    // Averages divide by the window tick count (a process alive for half the
+    // window with 100% CPU averages 50%) - the "who ate my CPU" semantics.
+    [[nodiscard]] std::vector<ProcessAggregate> aggregate(size_t max_samples) const;
+
+    // Single-metric series for one PID over the most recent max_points ticks
+    // (oldest -> newest, 0 where the PID did not exist). For sparklines.
+    [[nodiscard]] std::vector<float> get_metric_series(int pid, HistoryMetric metric,
+                                                       size_t max_points) const;
 
     // Export everything to two CSV files next to each other:
     //   <base>-system.csv    one row per tick (system aggregates)

--- a/src/core/services/history_store.hpp
+++ b/src/core/services/history_store.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <deque>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace pex {
+
+struct DataSnapshot;
+
+// Compact per-process sample recorded every collection tick.
+struct ProcessSample {
+    int pid = 0;
+    float cpu_user_percent = 0.0f;    // Share of all cores (0-100)
+    float cpu_kernel_percent = 0.0f;  // Share of all cores (0-100)
+    float memory_percent = 0.0f;
+    int64_t resident_memory = 0;
+    float io_read_rate = 0.0f;        // bytes/sec
+    float io_write_rate = 0.0f;       // bytes/sec
+};
+
+// One tick of recorded history: system aggregates + all process samples.
+struct HistorySample {
+    std::chrono::system_clock::time_point wall_time;
+    float cpu_usage = 0.0f;
+    int64_t memory_used = 0;
+    int64_t memory_total = 0;
+    int process_count = 0;
+    int thread_count = 0;
+    std::vector<float> per_cpu_user;
+    std::vector<float> per_cpu_system;
+    std::vector<ProcessSample> processes;
+};
+
+// Aligned series for charting a set of PIDs (values summed across the set).
+// Vectors run oldest -> newest and all have the same length.
+struct ProcessHistorySeries {
+    std::vector<float> cpu_user;       // % of all cores
+    std::vector<float> cpu_kernel;     // % of all cores
+    std::vector<float> memory_percent;
+    std::vector<std::vector<float>> per_cpu_user;    // [cpu][tick] system-wide
+    std::vector<std::vector<float>> per_cpu_kernel;  // [cpu][tick] system-wide
+};
+
+// Ring buffer of system + per-process samples (issue #9).
+// record() is called from the DataStore collection thread; all query and
+// export methods are safe to call concurrently from the UI thread.
+class HistoryStore {
+public:
+    explicit HistoryStore(size_t max_samples = kDefaultMaxSamples);
+
+    // Record one tick. Called by DataStore after a snapshot is built.
+    void record(const DataSnapshot& snapshot);
+
+    [[nodiscard]] size_t sample_count() const;
+
+    // Summed series for a set of PIDs (e.g. a process subtree), most recent
+    // max_points ticks. Ticks where none of the PIDs existed contribute 0.
+    [[nodiscard]] ProcessHistorySeries get_series(const std::vector<int>& pids,
+                                                  size_t max_points) const;
+
+    // Export everything to two CSV files next to each other:
+    //   <base>-system.csv    one row per tick (system aggregates)
+    //   <base>-processes.csv one row per process per tick
+    // Returns true on success; on failure fills 'error'.
+    bool export_csv(const std::string& base_path, std::string& error) const;
+
+    static constexpr size_t kDefaultMaxSamples = 600;
+
+private:
+    mutable std::mutex mutex_;
+    std::deque<HistorySample> samples_;
+    size_t max_samples_;
+    std::unordered_map<int, std::string> process_names_;  // pid -> last-known name
+};
+
+} // namespace pex

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include "platform/platform_factory.hpp"
 #include "core/services/data_store.hpp"
+#include "core/services/history_store.hpp"
 #include "ui/imgui/imgui_app.hpp"
 #include "core/services/single_instance.hpp"
 #include <iostream>
@@ -33,9 +34,12 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[]) {
         const auto system_provider = pex::make_system_data_provider();
         const auto killer = pex::make_process_killer();
 
+        pex::HistoryStore history_store;
         pex::DataStore data_store(process_provider.get(), system_provider.get());
+        data_store.set_history_store(&history_store);
 
-        pex::ImGuiApp app(&data_store, system_provider.get(), details_provider.get(), killer.get());
+        pex::ImGuiApp app(&data_store, system_provider.get(), details_provider.get(), killer.get(),
+                          &history_store);
 
         instance.set_raise_callback([&app]() {
             app.request_focus();

--- a/src/main_tui.cpp
+++ b/src/main_tui.cpp
@@ -1,5 +1,6 @@
 #include "platform/platform_factory.hpp"
 #include "core/services/data_store.hpp"
+#include "core/services/history_store.hpp"
 #include "ui/tui/tui_app.hpp"
 #include <iostream>
 #include <csignal>
@@ -27,9 +28,12 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[]) {
         const auto system_provider = pex::make_system_data_provider();
         const auto killer = pex::make_process_killer();
 
+        pex::HistoryStore history_store;
         pex::DataStore data_store(process_provider.get(), system_provider.get());
+        data_store.set_history_store(&history_store);
 
-        pex::TuiApp app(&data_store, system_provider.get(), details_provider.get(), killer.get());
+        pex::TuiApp app(&data_store, system_provider.get(), details_provider.get(), killer.get(),
+                        &history_store);
         app.run();
         return 0;
     } catch (const std::exception& e) {

--- a/src/platform/linux/procfs/procfs_processes.cpp
+++ b/src/platform/linux/procfs/procfs_processes.cpp
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #include <format>
 #include <charconv>
+#include <string_view>
 #include <algorithm>
 
 namespace fs = std::filesystem;
@@ -129,6 +130,20 @@ std::optional<ProcessInfo> ProcfsReader::get_process_info(int pid, int64_t total
     info.command_line = cmdline;
 
     info.executable_path = read_symlink(proc_path + "/exe");
+
+    // Storage I/O counters. /proc/<pid>/io needs the same privilege as ptrace
+    // read access; unreadable (other users' processes without caps) leaves 0.
+    if (std::string io = read_file(proc_path + "/io"); !io.empty()) {
+        auto parse_io_field = [&io](const std::string_view key, uint64_t& out) {
+            const size_t pos = io.find(key);
+            if (pos == std::string::npos) return;
+            size_t v = pos + key.size();
+            while (v < io.size() && io[v] == ' ') v++;
+            std::from_chars(io.data() + v, io.data() + io.size(), out);
+        };
+        parse_io_field("read_bytes:", info.io_read_bytes);
+        parse_io_field("write_bytes:", info.io_write_bytes);
+    }
 
     std::string status = read_file(proc_path + "/status");
     std::istringstream status_iss(status);

--- a/src/ui/common/viewmodels/process_popup_view_model.hpp
+++ b/src/ui/common/viewmodels/process_popup_view_model.hpp
@@ -16,8 +16,9 @@ struct ProcessPopupViewModel {
     // Toggle: false = process only, true = process + descendants
     bool include_tree = true;
 
-    // History buffers for charts
-    static constexpr size_t kHistorySize = 60;  // 60 data points
+    // History buffers for charts. Matches HistoryStore::kDefaultMaxSamples so
+    // the backfill shows the full recorded depth (~10 min at 1 s refresh).
+    static constexpr size_t kHistorySize = 600;
     std::vector<float> cpu_user_history;
     std::vector<float> cpu_kernel_history;
     std::vector<float> memory_history;

--- a/src/ui/common/viewmodels/process_popup_view_model.hpp
+++ b/src/ui/common/viewmodels/process_popup_view_model.hpp
@@ -33,6 +33,10 @@ struct ProcessPopupViewModel {
     // Last update timestamp for rate limiting
     std::chrono::steady_clock::time_point last_update;
 
+    // Set when the target changes; the next update seeds the charts from the
+    // HistoryStore so past data is visible immediately (issue #9)
+    bool needs_backfill = false;
+
     // Clear all history when changing target
     void clear_history() {
         cpu_user_history.clear();
@@ -42,6 +46,7 @@ struct ProcessPopupViewModel {
         per_cpu_kernel_history.clear();
         prev_utime = 0;
         prev_stime = 0;
+        needs_backfill = true;
     }
 };
 

--- a/src/ui/imgui/imgui_app.cpp
+++ b/src/ui/imgui/imgui_app.cpp
@@ -350,6 +350,7 @@ void ImGuiApp::render() {
     render_process_popup();
     render_kill_confirmation_dialog();
     render_find_handle_dialog();
+    render_history_view();
 }
 
 } // namespace pex

--- a/src/ui/imgui/imgui_app.cpp
+++ b/src/ui/imgui/imgui_app.cpp
@@ -3,7 +3,9 @@
 #include "imgui_impl_glfw.h"
 #include "imgui_impl_opengl3.h"
 #include "../../core/format_utils.hpp"
+#include "../../core/services/history_store.hpp"
 #include <GLFW/glfw3.h>
+#include <cstdlib>
 #include <format>
 #include <ctime>
 #include <fstream>
@@ -19,11 +21,13 @@ namespace pex {
 ImGuiApp::ImGuiApp(DataStore* data_store,
                    ISystemDataProvider* system_provider,
                    IProcessDataProvider* details_provider,
-                   IProcessKiller* killer)
+                   IProcessKiller* killer,
+                   HistoryStore* history)
     : data_store_(data_store)
     , system_provider_(system_provider)
     , details_provider_(details_provider)
-    , killer_(killer) {
+    , killer_(killer)
+    , history_(history) {
 
     // Validate required dependencies
     assert(data_store_ && "DataStore must not be null");
@@ -42,7 +46,9 @@ ImGuiApp::ImGuiApp(DataStore* data_store,
     });
 }
 
-ImGuiApp::~ImGuiApp() = default;
+ImGuiApp::~ImGuiApp() {
+    stop_handle_search();
+}
 
 void ImGuiApp::run() {
     // Initialize GLFW
@@ -163,7 +169,8 @@ void ImGuiApp::run() {
         glfwSwapBuffers(window_);
     }
 
-    // Stop background threads
+    // Stop background threads (find worker first: it posts GLFW events)
+    stop_handle_search();
     data_store_->stop();
     name_resolver_.stop();
 
@@ -179,6 +186,27 @@ void ImGuiApp::run() {
 void ImGuiApp::request_focus() {
     focus_requested_ = true;
     post_empty_event_debounced();
+}
+
+void ImGuiApp::export_history() {
+    if (!history_) return;
+
+    const char* home = std::getenv("HOME");
+    const auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    std::tm tm_val{};
+    localtime_r(&now, &tm_val);
+    char stamp[32];
+    std::strftime(stamp, sizeof(stamp), "%Y%m%d-%H%M%S", &tm_val);
+
+    const std::string base = std::string(home ? home : ".") + "/pex-history-" + stamp;
+
+    std::string error;
+    if (history_->export_csv(base, error)) {
+        status_message_ = std::format("History exported to {}-{{system,processes}}.csv", base);
+    } else {
+        status_message_ = "History export failed: " + error;
+    }
+    status_message_time_ = std::chrono::steady_clock::now();
 }
 
 void ImGuiApp::post_empty_event_debounced() {
@@ -244,6 +272,12 @@ void ImGuiApp::render() {
     ImGui::EndChild();
 
     // Status bar
+    if (!status_message_.empty() &&
+        std::chrono::steady_clock::now() - status_message_time_ < kStatusMessageDuration) {
+        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.4f, 0.9f, 0.4f, 1.0f));
+        ImGui::TextWrapped("%s", status_message_.c_str());
+        ImGui::PopStyleColor();
+    }
     if (const auto errors = data_store_->get_recent_errors(); !errors.empty()) {
         ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.8f, 0.2f, 1.0f));
         ImGui::Text("[!] %s", errors.back().message.c_str());
@@ -315,6 +349,7 @@ void ImGuiApp::render() {
 
     render_process_popup();
     render_kill_confirmation_dialog();
+    render_find_handle_dialog();
 }
 
 } // namespace pex

--- a/src/ui/imgui/imgui_app.hpp
+++ b/src/ui/imgui/imgui_app.hpp
@@ -4,6 +4,7 @@
 #include "../../platform/interfaces/i_system_data_provider.hpp"
 #include "../../platform/interfaces/i_process_killer.hpp"
 #include "../../core/services/data_store.hpp"
+#include "../../core/services/history_store.hpp"
 #include "../common/viewmodels/app_view_model.hpp"
 #include "../../core/services/name_resolver.hpp"
 #include <memory>
@@ -11,13 +12,12 @@
 #include <mutex>
 #include <chrono>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 
 struct GLFWwindow;
 
 namespace pex {
-
-class HistoryStore;
 
 class ImGuiApp {
 public:
@@ -84,6 +84,9 @@ private:
     void start_handle_search();
     void stop_handle_search();
 
+    // History / Top Consumers view (issue #9)
+    void render_history_view();
+
     // History export (File menu)
     void export_history();
 
@@ -146,6 +149,18 @@ private:
     // details_provider_ with the UI thread.
     std::unique_ptr<IProcessDataProvider> find_provider_;
     static constexpr size_t kMaxFindResults = 5000;
+
+    // ---- History / Top Consumers view (issue #9) ----
+    bool history_view_visible_ = false;
+    int history_metric_idx_ = 0;   // 0=CPU 1=Memory 2=IO read 3=IO write
+    int history_window_idx_ = 2;   // 0=1min 1=5min 2=all recorded
+    // Cached aggregation (recomputed on parameter change or every second)
+    std::vector<ProcessAggregate> history_aggregates_;
+    std::unordered_map<int, std::vector<float>> history_sparklines_;
+    std::chrono::steady_clock::time_point history_cache_time_{};
+    int history_cache_metric_ = -1;
+    int history_cache_window_ = -1;
+    static constexpr size_t kHistoryTopN = 25;
 };
 
 } // namespace pex

--- a/src/ui/imgui/imgui_app.hpp
+++ b/src/ui/imgui/imgui_app.hpp
@@ -10,24 +10,31 @@
 #include <atomic>
 #include <mutex>
 #include <chrono>
+#include <thread>
+#include <vector>
 
 struct GLFWwindow;
 
 namespace pex {
 
+class HistoryStore;
+
 class ImGuiApp {
 public:
     // Non-owning constructor: ImGuiApp uses but does not own the data layer.
-    // All pointers must be non-null and must outlive the ImGuiApp instance.
+    // All pointers must be non-null and must outlive the ImGuiApp instance
+    // (history may be nullptr to disable history-backed features).
     // - data_store: background data collection (managed externally)
     // - system_provider: for system config queries (ticks/sec, cpu count)
     // - details_provider: for on-demand detail fetches (threads, files, etc.)
     // - killer: for process termination
-    // Precondition: all pointers != nullptr (asserted in constructor)
+    // - history: recorded per-tick samples for chart backfill and CSV export
+    // Precondition: pointers != nullptr (asserted in constructor)
     ImGuiApp(DataStore* data_store,
              ISystemDataProvider* system_provider,
              IProcessDataProvider* details_provider,
-             IProcessKiller* killer);
+             IProcessKiller* killer,
+             HistoryStore* history = nullptr);
     ~ImGuiApp();
 
     void run();
@@ -72,11 +79,25 @@ private:
     void execute_kill(bool force);
     static void collect_tree_pids(const ProcessNode* node, std::vector<int>& pids);
 
+    // Find open file/handle (issue #7)
+    void render_find_handle_dialog();
+    void start_handle_search();
+    void stop_handle_search();
+
+    // History export (File menu)
+    void export_history();
+
     // Non-owned references to data layer (managed externally)
     DataStore* data_store_ = nullptr;
     ISystemDataProvider* system_provider_ = nullptr;  // For config queries (ticks/sec, cpu count)
     IProcessDataProvider* details_provider_ = nullptr;
     IProcessKiller* killer_ = nullptr;
+    HistoryStore* history_ = nullptr;  // Optional (nullptr = history features disabled)
+
+    // Transient status message shown in the status bar (e.g. export result)
+    std::string status_message_;
+    std::chrono::steady_clock::time_point status_message_time_{};
+    static constexpr auto kStatusMessageDuration = std::chrono::seconds(10);
 
     // Current snapshot from data store
     std::shared_ptr<DataSnapshot> current_data_;
@@ -103,6 +124,28 @@ private:
     std::mutex event_debounce_mutex_;
     std::chrono::steady_clock::time_point last_event_post_time_;
     static constexpr auto kEventDebounceInterval = std::chrono::milliseconds(16);
+
+    // ---- Find open file/handle (issue #7) ----
+    struct HandleSearchResult {
+        int pid = 0;
+        std::string process_name;
+        std::string type;   // "file", "socket", "library", ...
+        std::string path;
+    };
+    bool find_dialog_visible_ = false;
+    bool find_focus_input_ = false;
+    char find_query_[256] = {};
+    int find_selected_row_ = -1;
+    std::atomic<bool> find_running_{false};
+    std::atomic<bool> find_cancel_{false};
+    std::thread find_thread_;                       // Worker; joined before restart/destruction
+    mutable std::mutex find_mutex_;                 // Guards results + status
+    std::vector<HandleSearchResult> find_results_;
+    std::string find_status_;
+    // Dedicated provider instance: the worker thread must not share
+    // details_provider_ with the UI thread.
+    std::unique_ptr<IProcessDataProvider> find_provider_;
+    static constexpr size_t kMaxFindResults = 5000;
 };
 
 } // namespace pex

--- a/src/ui/imgui/imgui_app_menus.cpp
+++ b/src/ui/imgui/imgui_app_menus.cpp
@@ -24,6 +24,9 @@ void ImGuiApp::render_menu_bar() {
             if (ImGui::MenuItem("Toggle Tree/List View", "T")) {
                 view_model_.process_list.is_tree_view = !view_model_.process_list.is_tree_view;
             }
+            if (ImGui::MenuItem("History - Top Consumers...", nullptr, false, history_ != nullptr)) {
+                history_view_visible_ = true;
+            }
             ImGui::Separator();
             if (ImGui::MenuItem("Refresh Now", "F5")) {
                 details_force_refresh_ = true;

--- a/src/ui/imgui/imgui_app_menus.cpp
+++ b/src/ui/imgui/imgui_app_menus.cpp
@@ -7,6 +7,13 @@ namespace pex {
 void ImGuiApp::render_menu_bar() {
     if (ImGui::BeginMenuBar()) {
         if (ImGui::BeginMenu("File")) {
+            if (ImGui::MenuItem("Export History to CSV...", nullptr, false, history_ != nullptr)) {
+                export_history();
+            }
+            if (ImGui::IsItemHovered()) {
+                ImGui::SetTooltip("Writes recorded per-tick system and per-process samples\nto ~/pex-history-<timestamp>-{system,processes}.csv");
+            }
+            ImGui::Separator();
             if (ImGui::MenuItem("Exit", "Alt+F4")) {
                 glfwSetWindowShouldClose(glfwGetCurrentContext(), GLFW_TRUE);
             }
@@ -21,6 +28,14 @@ void ImGuiApp::render_menu_bar() {
             if (ImGui::MenuItem("Refresh Now", "F5")) {
                 details_force_refresh_ = true;
                 data_store_->refresh_now();
+            }
+            ImGui::EndMenu();
+        }
+
+        if (ImGui::BeginMenu("Find")) {
+            if (ImGui::MenuItem("Find Open File / Handle...", "Ctrl+Shift+F")) {
+                find_dialog_visible_ = true;
+                find_focus_input_ = true;
             }
             ImGui::EndMenu();
         }

--- a/src/ui/imgui/imgui_find_handle_dialog.cpp
+++ b/src/ui/imgui/imgui_find_handle_dialog.cpp
@@ -1,0 +1,201 @@
+#include "imgui_app.hpp"
+#include "imgui.h"
+#include "../../platform/platform_factory.hpp"
+#include <algorithm>
+#include <cctype>
+#include <format>
+
+namespace pex {
+
+namespace {
+
+std::string lower_copy(const std::string& s) {
+    std::string result = s;
+    std::ranges::transform(result, result.begin(),
+                           [](unsigned char c) { return std::tolower(c); });
+    return result;
+}
+
+} // namespace
+
+void ImGuiApp::stop_handle_search() {
+    find_cancel_ = true;
+    if (find_thread_.joinable()) {
+        find_thread_.join();
+    }
+    find_cancel_ = false;
+}
+
+void ImGuiApp::start_handle_search() {
+    if (!current_data_) return;
+    stop_handle_search();  // Join any previous worker
+
+    const std::string query = lower_copy(find_query_);
+    if (query.empty()) return;
+
+    if (!find_provider_) {
+        find_provider_ = make_details_data_provider();
+    }
+
+    // Snapshot the PID list on the UI thread; the worker must not touch
+    // current_data_ (it is replaced by the UI thread every tick).
+    std::vector<std::pair<int, std::string>> targets;
+    targets.reserve(current_data_->process_map.size());
+    for (const auto& [pid, node] : current_data_->process_map) {
+        targets.emplace_back(pid, node->info.name);
+    }
+    std::ranges::sort(targets);
+
+    {
+        std::lock_guard lock(find_mutex_);
+        find_results_.clear();
+        find_status_ = "Scanning...";
+    }
+    find_selected_row_ = -1;
+    find_running_ = true;
+
+    find_thread_ = std::thread([this, query, targets = std::move(targets)]() {
+        size_t scanned = 0;
+        size_t total_matches = 0;
+
+        for (const auto& [pid, name] : targets) {
+            if (find_cancel_.load()) break;
+
+            std::vector<HandleSearchResult> batch;
+
+            for (const auto& fh : find_provider_->get_file_handles(pid)) {
+                if (lower_copy(fh.path).find(query) != std::string::npos) {
+                    batch.push_back({pid, name, fh.type, fh.path});
+                }
+            }
+            for (const auto& lib : find_provider_->get_libraries(pid)) {
+                if (lower_copy(lib.path).find(query) != std::string::npos) {
+                    batch.push_back({pid, name, "library", lib.path});
+                }
+            }
+
+            scanned++;
+            {
+                std::lock_guard lock(find_mutex_);
+                for (auto& r : batch) {
+                    if (find_results_.size() >= kMaxFindResults) break;
+                    find_results_.push_back(std::move(r));
+                }
+                total_matches = find_results_.size();
+                find_status_ = std::format("Scanning... {}/{} processes, {} matches",
+                                           scanned, targets.size(), total_matches);
+                if (find_results_.size() >= kMaxFindResults) {
+                    find_status_ = std::format("Stopped at {} matches (refine the query)", kMaxFindResults);
+                    break;
+                }
+            }
+
+            if (scanned % 10 == 0) {
+                post_empty_event_debounced();
+            }
+        }
+
+        {
+            std::lock_guard lock(find_mutex_);
+            if (find_cancel_.load()) {
+                find_status_ = std::format("Cancelled: {} matches in {} scanned processes",
+                                           total_matches, scanned);
+            } else if (find_results_.size() < kMaxFindResults) {
+                find_status_ = std::format("Done: {} matches in {} processes",
+                                           total_matches, scanned);
+            }
+        }
+        find_running_ = false;
+        post_empty_event_debounced();
+    });
+}
+
+void ImGuiApp::render_find_handle_dialog() {
+    if (!find_dialog_visible_) return;
+
+    ImGui::SetNextWindowSize(ImVec2(820, 480), ImGuiCond_FirstUseEver);
+    if (ImGui::Begin("Find Open File / Handle", &find_dialog_visible_)) {
+        if (ImGui::IsKeyPressed(ImGuiKey_Escape)) {
+            find_dialog_visible_ = false;
+            ImGui::End();
+            return;
+        }
+
+        if (find_focus_input_) {
+            ImGui::SetKeyboardFocusHere();
+            find_focus_input_ = false;
+        }
+        ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 220);
+        const bool enter = ImGui::InputTextWithHint("##find_query",
+            "path substring, e.g. .log, /var/lib, socket:", find_query_, sizeof(find_query_),
+            ImGuiInputTextFlags_EnterReturnsTrue);
+        ImGui::SameLine();
+
+        const bool running = find_running_.load();
+        if (running) {
+            if (ImGui::Button("Cancel", ImVec2(100, 0))) {
+                find_cancel_ = true;
+            }
+        } else {
+            if ((ImGui::Button("Search", ImVec2(100, 0)) || enter) && find_query_[0] != '\0') {
+                start_handle_search();
+            }
+        }
+        ImGui::SameLine();
+        ImGui::TextDisabled("(?)");
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Searches open file descriptors and mapped libraries of every\n"
+                              "process for a case-insensitive path substring.\n"
+                              "Other users' processes need elevated privileges to inspect.");
+        }
+
+        {
+            std::lock_guard lock(find_mutex_);
+            if (!find_status_.empty()) {
+                ImGui::TextDisabled("%s", find_status_.c_str());
+            }
+        }
+
+        if (ImGui::BeginTable("FindResults", 4,
+                ImGuiTableFlags_Resizable | ImGuiTableFlags_ScrollY |
+                ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersOuter)) {
+            ImGui::TableSetupScrollFreeze(0, 1);
+            ImGui::TableSetupColumn("Process", ImGuiTableColumnFlags_WidthFixed, 180);
+            ImGui::TableSetupColumn("PID", ImGuiTableColumnFlags_WidthFixed, 70);
+            ImGui::TableSetupColumn("Type", ImGuiTableColumnFlags_WidthFixed, 80);
+            ImGui::TableSetupColumn("Path", ImGuiTableColumnFlags_WidthStretch);
+            ImGui::TableHeadersRow();
+
+            std::lock_guard lock(find_mutex_);
+            for (int i = 0; i < static_cast<int>(find_results_.size()); i++) {
+                const auto& r = find_results_[i];
+                ImGui::PushID(i);
+                ImGui::TableNextRow();
+
+                ImGui::TableNextColumn();
+                if (ImGui::Selectable(r.process_name.c_str(), find_selected_row_ == i,
+                        ImGuiSelectableFlags_SpanAllColumns)) {
+                    find_selected_row_ = i;
+                    // Jump to the process in the main view
+                    view_model_.process_list.selected_pid = r.pid;
+                    expand_ancestors(r.pid);
+                    view_model_.process_list.scroll_to_selected = true;
+                    refresh_selected_details();
+                }
+
+                ImGui::TableNextColumn();
+                ImGui::Text("%d", r.pid);
+                ImGui::TableNextColumn();
+                ImGui::Text("%s", r.type.c_str());
+                ImGui::TableNextColumn();
+                ImGui::Text("%s", r.path.c_str());
+
+                ImGui::PopID();
+            }
+            ImGui::EndTable();
+        }
+    }
+    ImGui::End();
+}
+
+} // namespace pex

--- a/src/ui/imgui/imgui_history_view.cpp
+++ b/src/ui/imgui/imgui_history_view.cpp
@@ -1,0 +1,185 @@
+#include "imgui_app.hpp"
+#include "imgui.h"
+#include "../../core/format_utils.hpp"
+#include <algorithm>
+#include <format>
+
+namespace pex {
+
+namespace {
+
+constexpr const char* kMetricNames[] = {"CPU", "Memory", "I/O Read", "I/O Write"};
+constexpr const char* kWindowNames[] = {"Last 1 min", "Last 5 min", "All recorded"};
+
+HistoryMetric to_metric(const int idx) {
+    switch (idx) {
+        case 1: return HistoryMetric::Memory;
+        case 2: return HistoryMetric::IoRead;
+        case 3: return HistoryMetric::IoWrite;
+        default: return HistoryMetric::Cpu;
+    }
+}
+
+float metric_avg(const ProcessAggregate& a, const int idx) {
+    switch (idx) {
+        case 1: return a.avg_mem;
+        case 2: return a.avg_io_read;
+        case 3: return a.avg_io_write;
+        default: return a.avg_cpu;
+    }
+}
+
+float metric_peak(const ProcessAggregate& a, const int idx) {
+    switch (idx) {
+        case 1: return a.peak_mem;
+        case 2: return a.peak_io_read;
+        case 3: return a.peak_io_write;
+        default: return a.peak_cpu;
+    }
+}
+
+std::string format_metric(const float value, const int idx) {
+    if (idx <= 1) {
+        return std::format("{:.1f}%", value);
+    }
+    if (value < 1.0f) return "-";
+    return format_bytes(static_cast<int64_t>(value), false) + "/s";
+}
+
+} // namespace
+
+void ImGuiApp::render_history_view() {
+    if (!history_view_visible_ || !history_) return;
+
+    ImGui::SetNextWindowSize(ImVec2(760, 540), ImGuiCond_FirstUseEver);
+    if (ImGui::Begin("History - Top Consumers", &history_view_visible_)) {
+        if (ImGui::IsKeyPressed(ImGuiKey_Escape)) {
+            history_view_visible_ = false;
+            ImGui::End();
+            return;
+        }
+
+        // Controls
+        ImGui::SetNextItemWidth(140);
+        ImGui::Combo("Metric", &history_metric_idx_, kMetricNames, IM_ARRAYSIZE(kMetricNames));
+        ImGui::SameLine();
+        ImGui::SetNextItemWidth(140);
+        ImGui::Combo("Window", &history_window_idx_, kWindowNames, IM_ARRAYSIZE(kWindowNames));
+        ImGui::SameLine();
+        {
+            const int refresh_ms = data_store_->get_refresh_interval();
+            const size_t recorded = history_->sample_count();
+            const double span_sec = static_cast<double>(recorded) * refresh_ms / 1000.0;
+            ImGui::TextDisabled("(%zu ticks recorded, ~%.0f s span)", recorded, span_sec);
+        }
+
+        // Window selection -> tick count
+        const int refresh_ms = std::max(1, data_store_->get_refresh_interval());
+        size_t window_ticks = SIZE_MAX;  // All recorded
+        if (history_window_idx_ == 0) window_ticks = static_cast<size_t>(60'000 / refresh_ms);
+        else if (history_window_idx_ == 1) window_ticks = static_cast<size_t>(300'000 / refresh_ms);
+
+        // Refresh the cached aggregation on parameter change or once per second
+        const auto now = std::chrono::steady_clock::now();
+        const bool params_changed = history_cache_metric_ != history_metric_idx_ ||
+                                    history_cache_window_ != history_window_idx_;
+        if (params_changed || now - history_cache_time_ >= std::chrono::seconds(1)) {
+            history_aggregates_ = history_->aggregate(window_ticks);
+
+            const int metric = history_metric_idx_;
+            std::ranges::sort(history_aggregates_, [metric](const auto& a, const auto& b) {
+                return metric_avg(a, metric) > metric_avg(b, metric);
+            });
+            if (history_aggregates_.size() > kHistoryTopN) {
+                history_aggregates_.resize(kHistoryTopN);
+            }
+
+            history_sparklines_.clear();
+            for (const auto& agg : history_aggregates_) {
+                history_sparklines_[agg.pid] =
+                    history_->get_metric_series(agg.pid, to_metric(metric), window_ticks);
+            }
+
+            history_cache_time_ = now;
+            history_cache_metric_ = history_metric_idx_;
+            history_cache_window_ = history_window_idx_;
+        }
+
+        ImGui::Spacing();
+
+        if (ImGui::BeginTable("TopConsumers", 6,
+                ImGuiTableFlags_Resizable | ImGuiTableFlags_ScrollY |
+                ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersOuter)) {
+            ImGui::TableSetupScrollFreeze(0, 1);
+            ImGui::TableSetupColumn("Process", ImGuiTableColumnFlags_WidthFixed, 170);
+            ImGui::TableSetupColumn("PID", ImGuiTableColumnFlags_WidthFixed, 60);
+            ImGui::TableSetupColumn("Trend", ImGuiTableColumnFlags_WidthStretch);
+            ImGui::TableSetupColumn("Avg", ImGuiTableColumnFlags_WidthFixed, 85);
+            ImGui::TableSetupColumn("Peak", ImGuiTableColumnFlags_WidthFixed, 85);
+            ImGui::TableSetupColumn("Seen", ImGuiTableColumnFlags_WidthFixed, 55);
+            ImGui::TableHeadersRow();
+
+            const size_t total_window = std::min(window_ticks == SIZE_MAX
+                ? history_->sample_count() : window_ticks, history_->sample_count());
+
+            for (const auto& agg : history_aggregates_) {
+                const bool alive = current_data_ && current_data_->process_map.contains(agg.pid);
+
+                ImGui::PushID(agg.pid);
+                ImGui::TableNextRow();
+
+                ImGui::TableNextColumn();
+                if (!alive) ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.6f, 0.6f, 0.6f, 1.0f));
+                const std::string label = agg.name.empty() ? std::format("(pid {})", agg.pid)
+                                                           : agg.name;
+                if (ImGui::Selectable(label.c_str(), false, ImGuiSelectableFlags_SpanAllColumns)
+                        && alive) {
+                    // Jump to the process in the main view
+                    view_model_.process_list.selected_pid = agg.pid;
+                    expand_ancestors(agg.pid);
+                    view_model_.process_list.scroll_to_selected = true;
+                    refresh_selected_details();
+                }
+                if (!alive) {
+                    ImGui::PopStyleColor();
+                    if (ImGui::IsItemHovered()) ImGui::SetTooltip("Process has exited");
+                }
+
+                ImGui::TableNextColumn();
+                ImGui::Text("%d", agg.pid);
+
+                ImGui::TableNextColumn();
+                if (const auto it = history_sparklines_.find(agg.pid);
+                        it != history_sparklines_.end() && !it->second.empty()) {
+                    const float peak = metric_peak(agg, history_metric_idx_);
+                    ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.4f, 0.7f, 1.0f, 1.0f));
+                    ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.0f, 0.0f, 0.0f, 0.2f));
+                    ImGui::PlotLines("##spark", it->second.data(),
+                                     static_cast<int>(it->second.size()), 0, nullptr,
+                                     0.0f, std::max(peak, 0.001f),
+                                     ImVec2(ImGui::GetContentRegionAvail().x, 26));
+                    ImGui::PopStyleColor(2);
+                }
+
+                ImGui::TableNextColumn();
+                ImGui::Text("%s", format_metric(metric_avg(agg, history_metric_idx_), history_metric_idx_).c_str());
+
+                ImGui::TableNextColumn();
+                ImGui::Text("%s", format_metric(metric_peak(agg, history_metric_idx_), history_metric_idx_).c_str());
+
+                ImGui::TableNextColumn();
+                if (total_window > 0) {
+                    ImGui::Text("%.0f%%", 100.0 * static_cast<double>(agg.present_ticks)
+                                              / static_cast<double>(total_window));
+                }
+
+                ImGui::PopID();
+            }
+
+            ImGui::EndTable();
+        }
+    }
+    ImGui::End();
+}
+
+} // namespace pex

--- a/src/ui/imgui/imgui_input.cpp
+++ b/src/ui/imgui/imgui_input.cpp
@@ -58,6 +58,13 @@ std::vector<ProcessNode*> ImGuiApp::get_visible_items() const {
 void ImGuiApp::handle_keyboard_navigation() {
     auto& pl = view_model_.process_list;
 
+    // Ctrl+Shift+F opens the find-open-file dialog (issue #7)
+    if (ImGui::GetIO().KeyCtrl && ImGui::GetIO().KeyShift && ImGui::IsKeyPressed(ImGuiKey_F)) {
+        find_dialog_visible_ = true;
+        find_focus_input_ = true;
+        return;
+    }
+
     // Ctrl+F to focus search box
     if (ImGui::GetIO().KeyCtrl && ImGui::IsKeyPressed(ImGuiKey_F)) {
         pl.focus_search_box = true;

--- a/src/ui/imgui/imgui_process_list_view.cpp
+++ b/src/ui/imgui/imgui_process_list_view.cpp
@@ -1,5 +1,6 @@
 #include "imgui_app.hpp"
 #include "imgui.h"
+#include "../../core/format_utils.hpp"
 #include <format>
 #include <functional>
 #include <algorithm>
@@ -29,6 +30,8 @@ static constexpr const char* kColumnTooltips[] = {
     "Sum of Total% for process and all descendants",
     "Sum of memory for process and all descendants",
     "Sum of memory% for process and all descendants",
+    "Storage read rate (bytes/sec)",
+    "Storage write rate (bytes/sec)",
     "Number of threads",
     "Owner username",
     "R=Running, S=Sleeping, D=Disk, Z=Zombie, T=Stopped",
@@ -36,8 +39,10 @@ static constexpr const char* kColumnTooltips[] = {
     "Full command line with arguments"
 };
 
+static constexpr int kColumnCount = 17;
+
 static void show_column_tooltips() {
-    for (int col = 0; col < 15; col++) {
+    for (int col = 0; col < kColumnCount; col++) {
         if (ImGui::TableSetColumnIndex(col)) {
             if (ImGui::IsItemHovered()) {
                 ImGui::SetTooltip("%s", kColumnTooltips[col]);
@@ -46,10 +51,16 @@ static void show_column_tooltips() {
     }
 }
 
+// "-" for idle, otherwise e.g. "1.2 MB/s"
+static std::string format_io_rate(const double rate) {
+    if (rate < 1.0) return "-";
+    return pex::format_bytes(static_cast<int64_t>(rate), false) + "/s";
+}
+
 void ImGuiApp::render_process_tree() {
     if (!current_data_) return;
 
-    if (ImGui::BeginTable("ProcessTree", 15,
+    if (ImGui::BeginTable("ProcessTree", kColumnCount,
             ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable |
             ImGuiTableFlags_Hideable |
             ImGuiTableFlags_ScrollX | ImGuiTableFlags_ScrollY |
@@ -66,6 +77,8 @@ void ImGuiApp::render_process_tree() {
         ImGui::TableSetupColumn("Tree Tot", ImGuiTableColumnFlags_WidthFixed, 70);
         ImGui::TableSetupColumn("Tree Mem", ImGuiTableColumnFlags_WidthFixed, 90);
         ImGui::TableSetupColumn("Tree %", ImGuiTableColumnFlags_WidthFixed, 60);
+        ImGui::TableSetupColumn("Read/s", ImGuiTableColumnFlags_WidthFixed, 80);
+        ImGui::TableSetupColumn("Write/s", ImGuiTableColumnFlags_WidthFixed, 80);
         ImGui::TableSetupColumn("Threads", ImGuiTableColumnFlags_WidthFixed, 60);
         ImGui::TableSetupColumn("User", ImGuiTableColumnFlags_WidthFixed, 100);
         ImGui::TableSetupColumn("State", ImGuiTableColumnFlags_WidthFixed, 50);
@@ -157,6 +170,12 @@ void ImGuiApp::render_process_tree_node(ProcessNode& node, const int depth) {
     ImGui::TextColored(ImVec4(0.4f, 0.6f, 1.0f, 1.0f), "%.1f", node.tree_memory_percent);
 
     ImGui::TableNextColumn();
+    ImGui::Text("%s", format_io_rate(node.info.io_read_rate).c_str());
+
+    ImGui::TableNextColumn();
+    ImGui::Text("%s", format_io_rate(node.info.io_write_rate).c_str());
+
+    ImGui::TableNextColumn();
     ImGui::Text("%d", node.info.thread_count);
 
     ImGui::TableNextColumn();
@@ -197,7 +216,7 @@ void ImGuiApp::render_process_tree_node(ProcessNode& node, const int depth) {
 void ImGuiApp::render_process_list() {
     if (!current_data_) return;
 
-    if (ImGui::BeginTable("ProcessList", 15,
+    if (ImGui::BeginTable("ProcessList", kColumnCount,
             ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable |
             ImGuiTableFlags_Hideable | ImGuiTableFlags_Sortable |
             ImGuiTableFlags_ScrollX | ImGuiTableFlags_ScrollY |
@@ -214,6 +233,8 @@ void ImGuiApp::render_process_list() {
         ImGui::TableSetupColumn("Tree Tot", ImGuiTableColumnFlags_WidthFixed, 70);
         ImGui::TableSetupColumn("Tree Mem", ImGuiTableColumnFlags_WidthFixed, 90);
         ImGui::TableSetupColumn("Tree %", ImGuiTableColumnFlags_WidthFixed, 60);
+        ImGui::TableSetupColumn("Read/s", ImGuiTableColumnFlags_WidthFixed, 80);
+        ImGui::TableSetupColumn("Write/s", ImGuiTableColumnFlags_WidthFixed, 80);
         ImGui::TableSetupColumn("Threads", ImGuiTableColumnFlags_WidthFixed, 60);
         ImGui::TableSetupColumn("User", ImGuiTableColumnFlags_WidthFixed, 100);
         ImGui::TableSetupColumn("State", ImGuiTableColumnFlags_WidthFixed, 50);
@@ -262,11 +283,13 @@ void ImGuiApp::render_process_list() {
                     case 7: result = (a->tree_total_cpu_percent < b->tree_total_cpu_percent) ? -1 : (a->tree_total_cpu_percent > b->tree_total_cpu_percent) ? 1 : 0; break;
                     case 8: result = (a->tree_working_set < b->tree_working_set) ? -1 : (a->tree_working_set > b->tree_working_set) ? 1 : 0; break;
                     case 9: result = (a->tree_memory_percent < b->tree_memory_percent) ? -1 : (a->tree_memory_percent > b->tree_memory_percent) ? 1 : 0; break;
-                    case 10: result = (a->info.thread_count < b->info.thread_count) ? -1 : (a->info.thread_count > b->info.thread_count) ? 1 : 0; break;
-                    case 11: result = a->info.user_name.compare(b->info.user_name); break;
-                    case 12: result = a->info.state_char - b->info.state_char; break;
-                    case 13: result = a->info.executable_path.compare(b->info.executable_path); break;
-                    case 14: result = a->info.command_line.compare(b->info.command_line); break;
+                    case 10: result = (a->info.io_read_rate < b->info.io_read_rate) ? -1 : (a->info.io_read_rate > b->info.io_read_rate) ? 1 : 0; break;
+                    case 11: result = (a->info.io_write_rate < b->info.io_write_rate) ? -1 : (a->info.io_write_rate > b->info.io_write_rate) ? 1 : 0; break;
+                    case 12: result = (a->info.thread_count < b->info.thread_count) ? -1 : (a->info.thread_count > b->info.thread_count) ? 1 : 0; break;
+                    case 13: result = a->info.user_name.compare(b->info.user_name); break;
+                    case 14: result = a->info.state_char - b->info.state_char; break;
+                    case 15: result = a->info.executable_path.compare(b->info.executable_path); break;
+                    case 16: result = a->info.command_line.compare(b->info.command_line); break;
                     default: result = 0; break;
                 }
                 return ascending ? (result < 0) : (result > 0);
@@ -317,6 +340,12 @@ void ImGuiApp::render_process_list() {
 
             ImGui::TableNextColumn();
             ImGui::TextColored(ImVec4(0.4f, 0.6f, 1.0f, 1.0f), "%.1f", node->tree_memory_percent);
+
+            ImGui::TableNextColumn();
+            ImGui::Text("%s", format_io_rate(node->info.io_read_rate).c_str());
+
+            ImGui::TableNextColumn();
+            ImGui::Text("%s", format_io_rate(node->info.io_write_rate).c_str());
 
             ImGui::TableNextColumn();
             ImGui::Text("%d", node->info.thread_count);

--- a/src/ui/imgui/imgui_process_popup_view.cpp
+++ b/src/ui/imgui/imgui_process_popup_view.cpp
@@ -1,5 +1,6 @@
 #include "imgui_app.hpp"
 #include "imgui.h"
+#include "../../core/services/history_store.hpp"
 #include <format>
 #include <algorithm>
 
@@ -16,6 +17,30 @@ void ImGuiApp::collect_tree_pids(const ProcessNode* node, std::vector<int>& pids
 void ImGuiApp::update_popup_history() {
     auto& pp = view_model_.process_popup;
     if (!pp.is_visible || pp.target_pid <= 0 || !current_data_) return;
+
+    // Seed the charts from recorded history so the past is visible the moment
+    // the popup opens (issue #9). Live sampling below then appends to it.
+    if (pp.needs_backfill) {
+        pp.needs_backfill = false;
+        if (history_) {
+            std::vector<int> backfill_pids;
+            if (const auto it = current_data_->process_map.find(pp.target_pid); it != current_data_->process_map.end()) {
+                if (pp.include_tree) {
+                    collect_tree_pids(it->second, backfill_pids);
+                } else {
+                    backfill_pids.push_back(pp.target_pid);
+                }
+            }
+            if (!backfill_pids.empty()) {
+                auto series = history_->get_series(backfill_pids, ProcessPopupViewModel::kHistorySize);
+                pp.cpu_user_history = std::move(series.cpu_user);
+                pp.cpu_kernel_history = std::move(series.cpu_kernel);
+                pp.memory_history = std::move(series.memory_percent);
+                pp.per_cpu_user_history = std::move(series.per_cpu_user);
+                pp.per_cpu_kernel_history = std::move(series.per_cpu_kernel);
+            }
+        }
+    }
 
     const auto now = std::chrono::steady_clock::now();
     const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - pp.last_update).count();
@@ -125,11 +150,7 @@ void ImGuiApp::render_process_popup() {
         }
 
         if (ImGui::Checkbox("Include descendants (process tree)", &pp.include_tree)) {
-            pp.cpu_user_history.clear();
-            pp.cpu_kernel_history.clear();
-            pp.memory_history.clear();
-            pp.prev_utime = 0;
-            pp.prev_stime = 0;
+            pp.clear_history();
         }
         if (pp.include_tree) {
             if (current_data_) {

--- a/src/ui/tui/tui_app.cpp
+++ b/src/ui/tui/tui_app.cpp
@@ -19,11 +19,13 @@ static void handle_resize([[maybe_unused]] int sig) {
 TuiApp::TuiApp(DataStore* data_store,
                ISystemDataProvider* system_provider,
                IProcessDataProvider* details_provider,
-               IProcessKiller* killer)
+               IProcessKiller* killer,
+               HistoryStore* history)
     : data_store_(data_store)
     , system_provider_(system_provider)
     , details_provider_(details_provider)
     , killer_(killer)
+    , history_(history)
 {
     assert(data_store_ != nullptr);
     assert(system_provider_ != nullptr);
@@ -32,6 +34,7 @@ TuiApp::TuiApp(DataStore* data_store,
 }
 
 TuiApp::~TuiApp() {
+    stop_find_scan();
     cleanup_windows();
 }
 
@@ -136,6 +139,11 @@ void TuiApp::run() {
             last_update = now;
         }
 
+        // Find-open-file worker progressed (issue #7)
+        if (find_dirty_.exchange(false)) {
+            needs_render = true;
+        }
+
         // Render only when something changed
         if (needs_render) {
             render();
@@ -144,6 +152,7 @@ void TuiApp::run() {
     }
 
     // Cleanup
+    stop_find_scan();
     data_store_->stop();
     name_resolver_.stop();
     cleanup_windows();
@@ -201,6 +210,14 @@ void TuiApp::render() {
 
     if (search_mode_) {
         render_search_bar();
+    }
+
+    if (find_file_mode_) {
+        render_find_file_bar();
+    }
+
+    if (find_results_visible_) {
+        render_find_results_overlay();
     }
 }
 

--- a/src/ui/tui/tui_app.hpp
+++ b/src/ui/tui/tui_app.hpp
@@ -6,13 +6,18 @@
 #include "../../core/services/data_store.hpp"
 #include "../../core/services/name_resolver.hpp"
 #include "../common/viewmodels/app_view_model.hpp"
+#include <chrono>
 #include <memory>
+#include <mutex>
 #include <atomic>
 #include <string>
+#include <thread>
 #include <vector>
 #include <ncurses.h>
 
 namespace pex {
+
+class HistoryStore;
 
 // Focus states for keyboard navigation between panels
 enum class PanelFocus {
@@ -23,11 +28,13 @@ enum class PanelFocus {
 class TuiApp {
 public:
     // Non-owning constructor: TuiApp uses but does not own the data layer.
-    // All pointers must be non-null and must outlive the TuiApp instance.
+    // All pointers must be non-null and must outlive the TuiApp instance
+    // (history may be nullptr to disable history-backed features).
     TuiApp(DataStore* data_store,
            ISystemDataProvider* system_provider,
            IProcessDataProvider* details_provider,
-           IProcessKiller* killer);
+           IProcessKiller* killer,
+           HistoryStore* history = nullptr);
     ~TuiApp();
 
     void run();
@@ -43,6 +50,17 @@ private:
 
     static void render_help_overlay();
     void render_search_bar() const;
+
+    // Find open file/handle (issue #7) - defined in tui_find_file.cpp
+    void render_find_file_bar() const;
+    void render_find_results_overlay();
+    void handle_find_file_input(int ch);
+    void handle_find_results_input(int ch);
+    void start_find_scan();
+    void stop_find_scan();
+
+    // History export (issue #9)
+    void export_history();
 
     // Tab rendering
     void render_file_handles_tab() const;
@@ -108,6 +126,7 @@ private:
     ISystemDataProvider* system_provider_ = nullptr;
     IProcessDataProvider* details_provider_ = nullptr;
     IProcessKiller* killer_ = nullptr;
+    HistoryStore* history_ = nullptr;  // Optional (nullptr = history features disabled)
 
     // Current snapshot from data store
     std::shared_ptr<DataSnapshot> current_data_;
@@ -152,6 +171,34 @@ private:
     int process_win_height_ = 0;
     int details_win_y_ = 0;
     int details_win_height_ = 0;
+
+    // Transient status message (e.g. history export result)
+    std::string status_message_;
+    std::chrono::steady_clock::time_point status_message_time_{};
+    static constexpr auto kStatusMessageDuration = std::chrono::seconds(8);
+
+    // ---- Find open file/handle (issue #7) ----
+    struct FindFileResult {
+        int pid = 0;
+        std::string process_name;
+        std::string type;   // "file", "socket", "library", ...
+        std::string path;
+    };
+    bool find_file_mode_ = false;       // Entering the query
+    bool find_results_visible_ = false; // Results overlay shown
+    std::string find_file_input_;
+    int find_selected_idx_ = 0;
+    int find_scroll_ = 0;
+    std::atomic<bool> find_running_{false};
+    std::atomic<bool> find_cancel_{false};
+    std::atomic<bool> find_dirty_{false};  // Worker progressed; main loop re-renders
+    std::thread find_thread_;              // Joined before restart/destruction
+    mutable std::mutex find_mutex_;        // Guards results + status
+    std::vector<FindFileResult> find_results_;
+    std::string find_status_;
+    // Dedicated provider: worker must not share details_provider_ with UI thread
+    std::unique_ptr<IProcessDataProvider> find_provider_;
+    static constexpr size_t kMaxFindResults = 5000;
 
     // Layout constants
     static constexpr int kSystemPanelCollapsedHeight = 3;  // Compact: avg CPU, mem, tasks

--- a/src/ui/tui/tui_find_file.cpp
+++ b/src/ui/tui/tui_find_file.cpp
@@ -1,0 +1,335 @@
+#include "tui_app.hpp"
+#include "tui_colors.hpp"
+#include "../../core/services/history_store.hpp"
+#include "../../platform/platform_factory.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <ctime>
+#include <format>
+
+namespace pex {
+
+namespace {
+
+std::string lower_copy(const std::string& s) {
+    std::string result = s;
+    std::ranges::transform(result, result.begin(),
+                           [](unsigned char c) { return std::tolower(c); });
+    return result;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// History export (issue #9)
+// ---------------------------------------------------------------------------
+
+void TuiApp::export_history() {
+    if (!history_) {
+        status_message_ = "History recording is not enabled";
+        status_message_time_ = std::chrono::steady_clock::now();
+        return;
+    }
+
+    const char* home = std::getenv("HOME");
+    const auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    std::tm tm_val{};
+    localtime_r(&now, &tm_val);
+    char stamp[32];
+    std::strftime(stamp, sizeof(stamp), "%Y%m%d-%H%M%S", &tm_val);
+
+    const std::string base = std::string(home ? home : ".") + "/pex-history-" + stamp;
+
+    std::string error;
+    if (history_->export_csv(base, error)) {
+        status_message_ = "History exported to " + base + "-{system,processes}.csv";
+    } else {
+        status_message_ = "History export failed: " + error;
+    }
+    status_message_time_ = std::chrono::steady_clock::now();
+}
+
+// ---------------------------------------------------------------------------
+// Find open file/handle (issue #7)
+// ---------------------------------------------------------------------------
+
+void TuiApp::stop_find_scan() {
+    find_cancel_ = true;
+    if (find_thread_.joinable()) {
+        find_thread_.join();
+    }
+    find_cancel_ = false;
+}
+
+void TuiApp::start_find_scan() {
+    if (!current_data_) return;
+    stop_find_scan();  // Join any previous worker
+
+    const std::string query = lower_copy(find_file_input_);
+    if (query.empty()) return;
+
+    if (!find_provider_) {
+        find_provider_ = make_details_data_provider();
+    }
+
+    // Snapshot the PID list on the UI thread; the worker must not touch
+    // current_data_ (the UI thread replaces it every tick).
+    std::vector<std::pair<int, std::string>> targets;
+    targets.reserve(current_data_->process_map.size());
+    for (const auto& [pid, node] : current_data_->process_map) {
+        targets.emplace_back(pid, node->info.name);
+    }
+    std::ranges::sort(targets);
+
+    {
+        std::lock_guard lock(find_mutex_);
+        find_results_.clear();
+        find_status_ = std::format("Scanning {} processes...", targets.size());
+    }
+    find_selected_idx_ = 0;
+    find_scroll_ = 0;
+    find_results_visible_ = true;
+    find_running_ = true;
+
+    find_thread_ = std::thread([this, query, targets = std::move(targets)]() {
+        size_t scanned = 0;
+        size_t total_matches = 0;
+
+        for (const auto& [pid, name] : targets) {
+            if (find_cancel_.load()) break;
+
+            std::vector<FindFileResult> batch;
+
+            for (const auto& fh : find_provider_->get_file_handles(pid)) {
+                if (lower_copy(fh.path).find(query) != std::string::npos) {
+                    batch.push_back({pid, name, fh.type, fh.path});
+                }
+            }
+            for (const auto& lib : find_provider_->get_libraries(pid)) {
+                if (lower_copy(lib.path).find(query) != std::string::npos) {
+                    batch.push_back({pid, name, "library", lib.path});
+                }
+            }
+
+            scanned++;
+            bool full = false;
+            {
+                std::lock_guard lock(find_mutex_);
+                for (auto& r : batch) {
+                    if (find_results_.size() >= kMaxFindResults) break;
+                    find_results_.push_back(std::move(r));
+                }
+                total_matches = find_results_.size();
+                find_status_ = std::format("Scanning... {}/{} processes, {} matches",
+                                           scanned, targets.size(), total_matches);
+                if (find_results_.size() >= kMaxFindResults) {
+                    find_status_ = std::format("Stopped at {} matches (refine the query)",
+                                               kMaxFindResults);
+                    full = true;
+                }
+            }
+            find_dirty_ = true;
+            if (full) break;
+        }
+
+        {
+            std::lock_guard lock(find_mutex_);
+            if (find_cancel_.load()) {
+                find_status_ = std::format("Cancelled: {} matches in {} scanned processes",
+                                           total_matches, scanned);
+            } else if (total_matches < kMaxFindResults) {
+                find_status_ = std::format("Done: {} matches in {} processes",
+                                           total_matches, scanned);
+            }
+        }
+        find_running_ = false;
+        find_dirty_ = true;
+    });
+}
+
+void TuiApp::handle_find_file_input(int ch) {
+    switch (ch) {
+        case 27:  // Escape
+            find_file_mode_ = false;
+            curs_set(0);
+            break;
+
+        case '\n':
+        case '\r':
+            find_file_mode_ = false;
+            curs_set(0);
+            if (!find_file_input_.empty()) {
+                start_find_scan();
+            }
+            break;
+
+        case KEY_BACKSPACE:
+        case 127:
+        case '\b':
+            if (!find_file_input_.empty()) {
+                find_file_input_.pop_back();
+            }
+            break;
+
+        default:
+            if (ch >= 32 && ch < 127) {
+                find_file_input_ += static_cast<char>(ch);
+            }
+            break;
+    }
+}
+
+void TuiApp::handle_find_results_input(int ch) {
+    int result_count;
+    {
+        std::lock_guard lock(find_mutex_);
+        result_count = static_cast<int>(find_results_.size());
+    }
+
+    switch (ch) {
+        case 27:  // Escape - cancel scan / close overlay
+        case 'q':
+            if (find_running_.load()) {
+                find_cancel_ = true;
+            }
+            find_results_visible_ = false;
+            break;
+
+        case KEY_UP:
+        case 'k':
+            if (find_selected_idx_ > 0) find_selected_idx_--;
+            break;
+
+        case KEY_DOWN:
+        case 'j':
+            if (find_selected_idx_ < result_count - 1) find_selected_idx_++;
+            break;
+
+        case KEY_PPAGE:
+            find_selected_idx_ = std::max(0, find_selected_idx_ - 10);
+            break;
+
+        case KEY_NPAGE:
+            if (result_count > 0) {
+                find_selected_idx_ = std::min(result_count - 1, find_selected_idx_ + 10);
+            }
+            break;
+
+        case '\n':
+        case '\r':
+            // Jump to the owning process in the main view
+            if (find_selected_idx_ >= 0 && find_selected_idx_ < result_count) {
+                int pid;
+                {
+                    std::lock_guard lock(find_mutex_);
+                    pid = find_results_[find_selected_idx_].pid;
+                }
+                if (current_data_ && current_data_->process_map.contains(pid)) {
+                    view_model_.process_list.selected_pid = pid;
+                    expand_ancestors(pid);
+                    scroll_to_selection();
+                    details_needs_refresh_ = true;
+                }
+                find_results_visible_ = false;
+            }
+            break;
+
+        case KEY_MOUSE: {
+            MEVENT event;
+            getmouse(&event);  // Consume; overlay has no mouse support
+            break;
+        }
+        default: ;
+    }
+}
+
+void TuiApp::render_find_file_bar() const {
+    int max_y, max_x;
+    getmaxyx(stdscr, max_y, max_x);
+
+    const int bar_y = max_y - 2;
+    const int bar_width = std::min(60, max_x - 4);
+    const int bar_x = (max_x - bar_width) / 2;
+
+    WINDOW* win = newwin(3, bar_width, bar_y, bar_x);
+    if (!win) return;
+
+    wbkgd(win, COLOR_PAIR(COLOR_PAIR_DIALOG));
+    box(win, 0, 0);
+
+    mvwprintw(win, 0, 2, " Find open file (path substring) ");
+    mvwprintw(win, 1, 2, "> %s", find_file_input_.c_str());
+
+    curs_set(1);
+    wmove(win, 1, 4 + static_cast<int>(find_file_input_.length()));
+
+    wrefresh(win);
+    delwin(win);
+}
+
+void TuiApp::render_find_results_overlay() {
+    int max_y, max_x;
+    getmaxyx(stdscr, max_y, max_x);
+
+    const int width = std::min(100, max_x - 4);
+    const int height = std::min(30, max_y - 4);
+    if (width < 30 || height < 6) return;
+    const int x = (max_x - width) / 2;
+    const int y = (max_y - height) / 2;
+
+    WINDOW* win = newwin(height, width, y, x);
+    if (!win) return;
+
+    wbkgd(win, COLOR_PAIR(COLOR_PAIR_DIALOG));
+    box(win, 0, 0);
+
+    wattron(win, A_BOLD);
+    mvwprintw(win, 0, 2, " Find: %s ", find_file_input_.c_str());
+    wattroff(win, A_BOLD);
+
+    std::lock_guard lock(find_mutex_);
+
+    // Status line
+    mvwprintw(win, 1, 2, "%.*s", width - 4, find_status_.c_str());
+
+    const int list_top = 2;
+    const int list_rows = height - list_top - 2;
+    const int count = static_cast<int>(find_results_.size());
+
+    // Keep selection visible
+    if (find_selected_idx_ >= count) find_selected_idx_ = std::max(0, count - 1);
+    if (find_selected_idx_ < find_scroll_) find_scroll_ = find_selected_idx_;
+    if (find_selected_idx_ >= find_scroll_ + list_rows) {
+        find_scroll_ = find_selected_idx_ - list_rows + 1;
+    }
+
+    for (int i = 0; i < list_rows && find_scroll_ + i < count; i++) {
+        const int idx = find_scroll_ + i;
+        const auto& r = find_results_[idx];
+
+        char line[512];
+        snprintf(line, sizeof(line), "%-16.16s %7d %-8.8s %s",
+                 r.process_name.c_str(), r.pid, r.type.c_str(), r.path.c_str());
+
+        if (idx == find_selected_idx_) {
+            wattron(win, COLOR_PAIR(COLOR_PAIR_SELECTED));
+            mvwhline(win, list_top + i, 1, ' ', width - 2);
+        }
+        mvwprintw(win, list_top + i, 2, "%.*s", width - 4, line);
+        if (idx == find_selected_idx_) {
+            wattroff(win, COLOR_PAIR(COLOR_PAIR_SELECTED));
+        }
+    }
+
+    wattron(win, COLOR_PAIR(COLOR_PAIR_DIALOG_BUTTON));
+    mvwprintw(win, height - 1, 2, " Enter:Go to process  Esc:%s ",
+              find_running_.load() ? "Cancel scan" : "Close");
+    wattroff(win, COLOR_PAIR(COLOR_PAIR_DIALOG_BUTTON));
+
+    wrefresh(win);
+    delwin(win);
+}
+
+} // namespace pex

--- a/src/ui/tui/tui_input.cpp
+++ b/src/ui/tui/tui_input.cpp
@@ -55,6 +55,16 @@ void TuiApp::handle_input(int ch) {
         return;
     }
 
+    // Find-open-file query input / results overlay (issue #7)
+    if (find_file_mode_) {
+        handle_find_file_input(ch);
+        return;
+    }
+    if (find_results_visible_) {
+        handle_find_results_input(ch);
+        return;
+    }
+
     // Global keys
     switch (ch) {
         case 'q':
@@ -72,6 +82,15 @@ void TuiApp::handle_input(int ch) {
         case '/':
             search_mode_ = true;
             search_input_.clear();
+            return;
+
+        case 'o':  // Find open file/handle (issue #7)
+            find_file_mode_ = true;
+            find_file_input_.clear();
+            return;
+
+        case 'd':  // Dump (export) recorded history to CSV (issue #9)
+            export_history();
             return;
 
         case 'n':  // Next search match

--- a/src/ui/tui/tui_kill_dialog.cpp
+++ b/src/ui/tui/tui_kill_dialog.cpp
@@ -1,5 +1,6 @@
 #include "tui_app.hpp"
 #include "tui_colors.hpp"
+#include <algorithm>
 #include <sstream>
 
 namespace pex {
@@ -87,9 +88,9 @@ void TuiApp::render_help_overlay() {
     int max_y, max_x;
     getmaxyx(stdscr, max_y, max_x);
 
-    // Help dialog dimensions
+    // Help dialog dimensions (shrink to fit small terminals; content clips)
     constexpr int help_width = 60;
-    constexpr int help_height = 31;
+    const int help_height = std::min(39, max_y - 2);
     const int help_x = (max_x - help_width) / 2;
     const int help_y = (max_y - help_height) / 2;
 
@@ -134,6 +135,8 @@ void TuiApp::render_help_overlay() {
         "Actions:",
         "  /               Search mode",
         "  n/N             Next/previous search match",
+        "  o               Find open file/handle",
+        "  d               Dump history to CSV (~/pex-history-*)",
         "  x               Kill process",
         "  K               Kill process tree",
         "  r/F5            Force refresh",
@@ -179,8 +182,17 @@ void TuiApp::render_status_bar() const {
     wbkgd(status_win_, COLOR_PAIR(COLOR_PAIR_STATUS));
     werase(status_win_);
 
+    // Transient status message (e.g. history export result) replaces hints
+    if (!status_message_.empty() &&
+        std::chrono::steady_clock::now() - status_message_time_ < kStatusMessageDuration) {
+        wattron(status_win_, A_BOLD);
+        mvwprintw(status_win_, 0, 1, "%.*s", max_x - 2, status_message_.c_str());
+        wattroff(status_win_, A_BOLD);
+        return;
+    }
+
     // Left side: key hints
-    const char* hints = "q:Quit  /:Search  s:System  c:CPUs  Tab:Panel  x:Kill  ?:Help";
+    const char* hints = "q:Quit  /:Search  o:FindFile  d:HistCSV  s:System  Tab:Panel  x:Kill  ?:Help";
     mvwprintw(status_win_, 0, 1, "%s", hints);
 
     // Right side: search text if active

--- a/src/ui/tui/tui_process_list.cpp
+++ b/src/ui/tui/tui_process_list.cpp
@@ -1,5 +1,6 @@
 #include "tui_app.hpp"
 #include "tui_colors.hpp"
+#include "../../core/format_utils.hpp"
 #include <sstream>
 #include <iomanip>
 #include <algorithm>
@@ -7,6 +8,12 @@
 #include <set>
 
 namespace pex {
+
+// "-" for idle, otherwise compact e.g. "1.2M/s" (issue #11)
+static std::string format_io_rate_tui(const double rate) {
+    if (rate < 1.0) return "-";
+    return pex::format_bytes(static_cast<int64_t>(rate), true) + "/s";
+}
 
 // Helper to check if a node is the last child of its parent
 static bool is_last_child(ProcessNode* node, const std::unordered_map<int, ProcessNode*>& process_map) {
@@ -82,7 +89,7 @@ void TuiApp::render_process_tree() {
     constexpr int tree_col_width = 32;
 
     // Scrollable header columns
-    const std::string header_scroll = "   PID   CPU%    Memory  Mem% Threads User     State TrCPU% TrTot%   TreeMem  Command";
+    const std::string header_scroll = "   PID   CPU%    Memory  Mem%  Read/s Write/s Threads User     State TrCPU% TrTot%   TreeMem  Command";
 
     // Render fixed header (Process column)
     wattron(process_win_, COLOR_PAIR(COLOR_PAIR_HEADER) | A_BOLD);
@@ -212,11 +219,13 @@ void TuiApp::render_process_tree() {
         // Build scrollable data row
         char data_buf[512];
         snprintf(data_buf, sizeof(data_buf),
-                 "%7d %5.1f%% %9s %4.1f%% %7d %-8s    %c  %5.1f%% %5.1f%% %9s  %s",
+                 "%7d %5.1f%% %9s %4.1f%% %7s %7s %7d %-8s    %c  %5.1f%% %5.1f%% %9s  %s",
                  info.pid,
                  info.cpu_percent,
                  format_bytes(info.resident_memory).c_str(),
                  info.memory_percent,
+                 format_io_rate_tui(info.io_read_rate).c_str(),
+                 format_io_rate_tui(info.io_write_rate).c_str(),
                  info.thread_count,
                  info.user_name.substr(0, 8).c_str(),
                  info.state_char,


### PR DESCRIPTION
Implements three features in both the GUI (pex) and TUI (pexc):

## Issue #11 — I/O statistics
- `ProcessInfo` carries cumulative `io_read_bytes`/`io_write_bytes` (Linux: `/proc/<pid>/io`); DataStore computes bytes/sec rates with the same PID-reuse guards as CPU deltas
- GUI: sortable **Read/s** / **Write/s** columns in tree and list views
- TUI: same columns in the scrollable process list
- FreeBSD/Solaris counters are a follow-up (columns show `-` there) — suggest keeping #11 open retitled for that remainder, or closing it

## Issue #9 — history (the original project idea)
- New `HistoryStore` core service: ring buffer (600 ticks ≈ 10 min at 1 s refresh) of system aggregates + per-process samples (CPU user/kernel split, memory, I/O rates), recorded from the collection thread
- Process popup charts are backfilled from history on open and now hold the full recorded depth — the past is visible immediately
- **View → History – Top Consumers**: rank top 25 processes by average CPU/Memory/IO over 1 min / 5 min / all recorded, with trend sparklines, avg/peak, presence %, click-to-jump; exited processes stay visible (dimmed)
- CSV export: GUI **File → Export History to CSV**, TUI **`d`** key → `~/pex-history-<ts>-{system,processes}.csv`

## Issue #7 — find open file/handle
- GUI: **Ctrl+Shift+F** dialog; TUI: **`o`** key + results overlay
- Background worker scans every process's fds and mapped libraries for a case-insensitive path substring (dedicated provider instance, joined on shutdown); results jump to the owning process

## Verification
- Clean Release builds, zero warnings (`-Wall -Wextra -Wpedantic`)
- Scripted pty tests for the TUI (history CSV contents verified, find scan completes, clean quit); GUI memory parity with main (158 vs 157 MB RSS)
- Multi-platform CI green on all four platforms for every commit on this branch

Closes #7
Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)