### PR TITLE
README refresh, kernel-thread toggle, persistent settings, privileges guide (#1, #2, #3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ add_library(pex_core STATIC
     src/core/services/data_store.cpp
     src/core/services/history_store.cpp
     src/core/services/name_resolver.cpp
+    src/core/services/settings.cpp
     src/core/services/single_instance.cpp
     src/core/model/system_info.cpp
 )

--- a/PRIVILEGES.md
+++ b/PRIVILEGES.md
@@ -181,3 +181,41 @@ Footnotes:
   from non-root regardless of the above.
 * Settings saved while running under sudo land in **root's**
   `~/.config/pex/pex.conf` (and root's `imgui.ini`), not yours.
+
+---
+
+## Nuclear alternative: setuid root (works everywhere, recommended nowhere)
+
+For completeness — it works on all three OSes:
+
+```bash
+sudo chown root /opt/pex/pexc
+sudo chmod u+s /opt/pex/pexc
+```
+
+Understand what you are buying: pex needs privileged reads on **every refresh
+tick**, so unlike a well-behaved setuid program it cannot elevate briefly and
+drop — the *entire* application holds root for its whole lifetime. That root
+is then held by code that was never written to be privilege-safe:
+
+* the **DNS resolver** — the network tab does reverse lookups of remote IPs
+  via `getnameinfo()`, i.e. a root process parsing hostile network data;
+* **ncurses** (TUI) — a long CVE history of parsing terminal/terminfo data;
+* **Mesa/GL drivers + GLFW + ImGui** (GUI) — a huge attack surface, and the
+  same root-on-Wayland problems as sudo anyway.
+
+A compromise of a `setcap` pex yields three capabilities; a compromise of a
+setuid pex yields the machine. On Linux and Solaris setuid buys *zero*
+functionality over the recipes above — only blast radius. The only place it
+is even arguable is FreeBSD (no finer mechanism exists), and there:
+
+* if you must, make only **`pexc`** setuid (no GL stack), never the GUI;
+* anyone who can execute the file gets root-powered pex — combine with the
+  group-restriction pattern from the Linux section (`chown root:pexusers`,
+  `chmod 4750`);
+* the *traditional* narrow BSD answer would be setgid `kmem` with a
+  libkvm-based backend (how `ps`/`top` historically worked) — pex's FreeBSD
+  backend currently uses sysctls, so this would require code changes; noted
+  here as the principled future option.
+
+To undo: `sudo chmod u-s /opt/pex/pexc`.

--- a/PRIVILEGES.md
+++ b/PRIVILEGES.md
@@ -1,0 +1,183 @@
+# HOW-TO: run pex with elevated privileges
+
+pex works without any special privileges: you always get the full process tree
+with CPU and memory for every process. Elevation is only needed to see the
+*details* of **other users' processes** (open files, network, environment,
+memory maps, I/O) and to kill them. Without it those panels just show
+"access denied" / stay empty for foreign processes.
+
+| OS | Mechanism | Scope of elevation | GUI-friendly |
+|---|---|---|---|
+| Linux | file capabilities (`setcap`) | 3 capabilities, this binary only | yes — works on Wayland, unlike sudo |
+| Solaris | RBAC profile + `pfexec` | 3 privileges, this binary + assigned users only | yes |
+| FreeBSD | `sudo` / `doas` | full root for the session | X11 only, see caveat |
+
+Do **not** make the binary setuid root: it would run the whole GUI/rendering
+stack as root, which is exactly what the recipes below avoid.
+
+Throughout, `/opt/pex/pex` and `/opt/pex/pexc` stand for wherever you
+installed the binaries — adjust paths.
+
+---
+
+## Linux (Debian)
+
+Capabilities used:
+
+* `cap_sys_ptrace` — read `/proc/<pid>/{environ,maps,io,fd,exe}` of other users' processes
+* `cap_dac_read_search` — bypass file-permission checks on procfs entries
+* `cap_kill` — send signals to other users' processes. **Optional**: drop it
+  from the commands below if you only want to observe, never kill.
+
+> Why not `sudo pex`? On GNOME/Wayland root GUI clients are blocked or
+> fragile, and sudo would write root-owned files into your `~/.config/pex`
+> and `imgui.ini`. With capabilities the process stays your user.
+
+### Option 1 — simple (single-user machine)
+
+1. Set the capabilities:
+   ```bash
+   sudo setcap 'cap_sys_ptrace,cap_dac_read_search,cap_kill+ep' /opt/pex/pex
+   sudo setcap 'cap_sys_ptrace,cap_dac_read_search,cap_kill+ep' /opt/pex/pexc   # if you use the TUI
+   ```
+2. Verify:
+   ```bash
+   getcap /opt/pex/pex
+   # /opt/pex/pex cap_dac_read_search,cap_kill,cap_sys_ptrace=ep
+   ```
+3. Run `pex` normally (no sudo). Select a root-owned process — the Files /
+   Network / Environment tabs should now be populated.
+
+Caveat: the capabilities apply to **anyone who can execute the file**. On a
+machine with other human accounts, use Option 2.
+
+Note: `setcap` must be re-applied after every rebuild/reinstall of the binary
+(the capability lives in the file's extended attributes).
+
+### Option 2 — restricted to a group (shared machine)
+
+1. Create a group and add yourself:
+   ```bash
+   sudo groupadd pexusers
+   sudo usermod -aG pexusers $USER
+   ```
+2. Log out and back in (or `newgrp pexusers`) so the group membership is active.
+3. Restrict execution of the binary to the group:
+   ```bash
+   sudo chown root:pexusers /opt/pex/pex
+   sudo chmod 750 /opt/pex/pex
+   ```
+4. Set the capabilities (same as Option 1):
+   ```bash
+   sudo setcap 'cap_sys_ptrace,cap_dac_read_search,cap_kill+ep' /opt/pex/pex
+   ```
+5. Verify: `pex` runs and shows foreign-process details for you; another
+   (non-member) user gets "Permission denied" when executing it.
+
+Repeat steps 3–4 for `/opt/pex/pexc` if wanted.
+
+Extra notes:
+* Capability-tagged binaries run in secure-exec mode (`LD_PRELOAD` etc. are
+  ignored) — that is a feature, not a bug.
+* If `/proc` is mounted with `hidepid=1/2`, visibility of foreign processes is
+  decided by the mount's `gid=` option; capabilities do not override `hidepid`.
+
+---
+
+## Solaris
+
+Privileges used:
+
+* `proc_owner` — inspect and signal other users' processes
+* `file_dac_read`, `file_dac_search` — read procfs entries regardless of permissions
+
+### Option 1 — RBAC execution profile + pfexec (recommended)
+
+Privileges apply only when running these exact binaries via `pfexec`.
+
+1. As root, define a rights profile — create `/etc/security/prof_attr.d/pex`
+   with the line:
+   ```
+   Pex Monitor:::Run pex with process observation privileges:
+   ```
+2. Attach the privileges to the pex binaries — create
+   `/etc/security/exec_attr.d/pex` with one line per binary:
+   ```
+   Pex Monitor:solaris:cmd:RO::/opt/pex/pex:privs=proc_owner,file_dac_read,file_dac_search
+   Pex Monitor:solaris:cmd:RO::/opt/pex/pexc:privs=proc_owner,file_dac_read,file_dac_search
+   ```
+   (The `exec_attr` lines are what actually carry the privileges — a
+   `prof_attr` entry alone grants nothing. The path must match exactly.)
+3. Assign the profile to your user:
+   ```bash
+   usermod -P +'Pex Monitor' <your-user>
+   ```
+4. Verify the assignment:
+   ```bash
+   profiles <your-user>        # should list: Pex Monitor
+   getent prof_attr "Pex Monitor"
+   ```
+5. Run via pfexec:
+   ```bash
+   pfexec /opt/pex/pexc
+   ```
+   To double-check the privileges took effect, run `ppriv <pid-of-pexc>` from
+   another terminal — the E (effective) set should include `proc_owner`.
+
+(The pex Solaris backend also shells out to `pfiles`/`pargs` as a fallback;
+those child processes inherit the privileges under `pfexec` automatically.)
+
+### Option 2 — default privileges for a user (personal box)
+
+Grants the privileges to **every process** of the user — no `pfexec` needed,
+but every program you run carries them. Prefer Option 1 on shared systems.
+
+1. As root:
+   ```bash
+   usermod -K defaultpriv=basic,proc_owner,file_dac_read,file_dac_search <your-user>
+   ```
+2. Log out and back in.
+3. Verify: `ppriv $$` — the E set should include `proc_owner`.
+4. Run `pex` / `pexc` normally.
+
+To undo: `usermod -K defaultpriv=basic <your-user>`.
+
+---
+
+## FreeBSD
+
+FreeBSD has no file capabilities (Capsicum only *drops* rights) and no RBAC —
+reading other users' file descriptors and environment genuinely requires
+root. Use `sudo` or `doas`.
+
+### TUI
+
+```bash
+sudo pexc
+```
+or, with `doas` (`pkg install doas`), add to `/usr/local/etc/doas.conf`:
+```
+permit persist <your-user> as root cmd /opt/pex/pexc
+```
+then:
+```bash
+doas /opt/pex/pexc
+```
+
+### GUI (X11)
+
+Root needs your X authority to open the display:
+```bash
+sudo -E pex
+```
+If that fails with "cannot open display", pass the authority explicitly:
+```bash
+sudo XAUTHORITY=$HOME/.Xauthority DISPLAY=$DISPLAY pex
+```
+
+Footnotes:
+* `security.bsd.see_other_uids=1` (the default) is what makes other users'
+  processes visible at all; hardened systems set it to 0, which hides them
+  from non-root regardless of the above.
+* Settings saved while running under sudo land in **root's**
+  `~/.config/pex/pex.conf` (and root's `imgui.ini`), not yours.

--- a/README.md
+++ b/README.md
@@ -112,18 +112,7 @@ ln -s /usr/lib/64/libX11.so.4 ./lib/libX11.so.6
 LD_LIBRARY_PATH=$PWD/lib ./pex
 ```
 This is not correct, but at least allowes to test.
-To make it possible for regular users to see properties of other users' processes, instead of `setcap` from Linux, in Solaris it would be something along:
-```bash
-username=user_x
-# su...
-# printf '%s\n' 'Pex Monitor:::Run pex with process/FD/network read privileges:::' >> /etc/security/prof_attr
-# grep -n "Pex Monitor" /etc/security/prof_attr
-# getent prof_attr "Pex Monitor"
-# usermod -P +"Pex Monitor" user_x
-# profiles rezdm | grep "Pex Monitor"
-...
-$ pfexec pex
-```
+To see properties of other users' processes, set up an RBAC profile and run via `pfexec` — see [PRIVILEGES.md](PRIVILEGES.md).
 
 ## Console version
 Additional functionality -- ncurses-based TUI version. Compiled by default together with GUI version. Not to build it:
@@ -165,6 +154,7 @@ Copy pex executable and pex.png to a folder of choice and set capabilities:
 ```bash
 sudo setcap 'cap_sys_ptrace,cap_dac_read_search,cap_kill+ep' {path-to-executable-location}/pex
 ```
+pex runs fine without this — you just won't see details (files, network, environment, ...) of other users' processes. For the full story per OS (Linux capabilities incl. a group-restricted variant, Solaris RBAC/pfexec, FreeBSD sudo/doas), see **[PRIVILEGES.md](PRIVILEGES.md)**.
 
 May be create .desktop file for GNOME:
 ```

--- a/README.md
+++ b/README.md
@@ -1,24 +1,77 @@
-# PEX - Process Explorer for Linux 
+# PEX - Process Explorer for Linux
 
-A Linux process explorer similar to Windows Process Explorer.
+A Linux process explorer similar to Windows Process Explorer. Also runs on FreeBSD and Solaris.
 
 ## Why
 
 I needed a one-off tool that would show me alltogether a process tree (think of pstree, ps -ef --forest or htop) but combined with network info. In Windows I'm using (since it appeared actually) Process Explorer and did not find anything alike for \*ix. Even though I am a FreeBSD and Solaris evangelist, this time it is for Debian Linux + Wayland only.
 
-It is AI generated code, it is a one-off project, not sure it makes sense to continue it, I needed it once and found it useful to have it on my computer.
+It started as AI generated code for a one-off need, then turned out to be useful enough to keep developing.
+
+## Features
+
+* **Process tree / list** with per-process CPU% (per-core and total), memory, threads, user, state, executable path and command line; subtree aggregates (tree CPU/memory)
+* **I/O rates** — per-process storage read/write bytes per second (Linux)
+* **Details panel** for the selected process: open file handles, network connections (with async DNS/service-name resolution), threads, memory maps, environment variables, loaded libraries
+* **History** — every refresh tick is recorded in memory (~10 min at 1 s refresh): per-process CPU (user/kernel split), memory and I/O rates plus system aggregates
+  * Process popup charts show the recorded past the moment you open them
+  * **History – Top Consumers** view (GUI): rank processes by average CPU / memory / I/O over the last 1 min / 5 min / all recorded, with trend sparklines — including processes that have already exited
+  * Export everything to CSV for offline analysis
+* **Find open file / handle** — search all processes for an open file, socket, pipe or loaded library by path substring (like Process Explorer's "Find Handle or DLL")
+* **Kill** process or whole process tree (SIGTERM, escalate to SIGKILL), with PID-reuse guards
+* **Search** by process name or command line, including processes under collapsed tree nodes
+* **Show/hide kernel threads** toggle
+* Single instance: launching pex again raises the existing window
+* Settings (window size, view mode, panels, refresh interval) persist across runs in `~/.config/pex/pex.conf`; GUI window/table layout persists via `imgui.ini`
+
+Two frontends, same data layer:
+* `pex` — GUI (Dear ImGui + GLFW + OpenGL), works on X11 and Wayland
+* `pexc` — ncurses TUI with near feature parity (no charts); ~5 MB RSS if memory matters
 
 ## Screenshots
 
-
 ![GUI version](pex-screenshot.png)
-
 
 ![Console (TUI) version](pexc-screenshot.png)
 
+## Keys
+
+### GUI (pex)
+
+| Key | Action |
+|---|---|
+| Ctrl+F | Focus search box |
+| F3 / Shift+F3 | Next / previous search match |
+| Ctrl+Shift+F | Find open file / handle |
+| F5 | Refresh now |
+| Delete (menu) | Kill process |
+| Arrows, PgUp/PgDn, Home/End | Navigate process list |
+| Double-click | Process details popup with history charts |
+
+History – Top Consumers is in the **View** menu; CSV export is in the **File** menu.
+
+### TUI (pexc)
+
+| Key | Action |
+|---|---|
+| Up/k, Down/j, PgUp/PgDn, Home/g, End/G | Navigate |
+| Enter/Right, Left | Expand / collapse tree node |
+| `<` `>` (or `,` `.`), `0` | Horizontal scroll, reset |
+| Tab | Switch panel focus |
+| 1-6 | Details tab by number |
+| `/`, n, N | Search, next/previous match |
+| o | Find open file / handle |
+| d | Dump recorded history to `~/pex-history-<timestamp>-{system,processes}.csv` |
+| u | Show/hide kernel threads |
+| x, K | Kill process / kill tree |
+| s, c | Toggle system panel / expand per-CPU view |
+| r / F5 | Refresh now |
+| ? / F1 | Help |
+| q | Quit |
+
 ## Requirements
 
-Being able to compile. Tested to run on:
+Being able to compile (C++23, CMake >= 3.20). Tested to run on:
 * Debian 13, GNOME/Wayland
 * Gentoo, KDE/X11
 * FreeBSD 15-RELEASE, XFCE/X11
@@ -41,8 +94,14 @@ make -j$(nproc)
   -DPEX_PLATFORM=solaris  # Solaris
 ```
 
+To build only the TUI (no X11/OpenGL needed):
+```bash
+cmake .. -DBUILD_GUI=OFF
+```
+
 #### FreeBSD
-I am using `pex` in FreeBSD 15-RELEASE, with XFCE, X11 in VirtualBox 7.2. Seems to work -- shows all that I need
+I am using `pex` in FreeBSD 15-RELEASE, with XFCE, X11 in VirtualBox 7.2. Seems to work -- shows all that I need.
+Note: per-process I/O byte counters and exact TCP states are not available through the FreeBSD APIs used; those columns show `-`/inferred values.
 
 #### Solaris
 I am testing `pex` on Solaris 11.4 CBE, with GNOME, X11 in VirtualBox 7.2. Works, but with an additional step, some workaround for libX11 limitation. libX11 itself resolves fine, but GLFW is reporting "Failed to load Xlib" likely because it can not `dlopen("libX11.so.6")` (hard-coded by GLFW) but my Solaris installation provides libX11.so.4. I did:
@@ -53,7 +112,7 @@ ln -s /usr/lib/64/libX11.so.4 ./lib/libX11.so.6
 LD_LIBRARY_PATH=$PWD/lib ./pex
 ```
 This is not correct, but at least allowes to test.
-Make make it possible to regular users to see properties of other's users processes, instead of `setcap` from Linux, in Solaris it would be something along
+To make it possible for regular users to see properties of other users' processes, instead of `setcap` from Linux, in Solaris it would be something along:
 ```bash
 username=user_x
 # su...
@@ -72,8 +131,16 @@ Additional functionality -- ncurses-based TUI version. Compiled by default toget
 ... -DBUILD_TUI=OFF
 ```
 
+The TUI also works with the system ncurses on Solaris 11.4:
+```bash
+cmake .. -DPEX_PLATFORM=solaris -DBUILD_GUI=OFF \
+  -DCURSES_INCLUDE_DIR=/usr/include/ncurses \
+  -DCURSES_LIBRARY=/usr/lib/64/libncursesw.so.6
+```
+(Mouse wheel-down needs ncurses mouse protocol v2 and is compiled out with the v1 system headers.)
+
 ### Challenges in Solaris
-Solaris has its own curses library that interferes with code. User should either compile/install ncurses manually or rely on this project's `CMakeLists.txt` to retrieve it: 
+Solaris has its own curses library that interferes with code. User should either compile/install ncurses manually or rely on this project's `CMakeLists.txt` to retrieve it:
 Compiling/installing manually, then:
 ```bash
 rm -rf * && \
@@ -123,14 +190,19 @@ update-desktop-database ~/.local/share/applications/
 
 Makes sense to crop/resize original logo into destination (with ImageMagic):
 ```bash
-convert {path-to-project-source}/pex-logo.png -gravity center -crop 800x800+0+0 +repage -resize 256x256 {path-to-installation-folder/pex.png 
+convert {path-to-project-source}/pex-logo.png -gravity center -crop 800x800+0+0 +repage -resize 256x256 {path-to-installation-folder/pex.png
 ```
 
-I am considering adding this to start it the same way as in Windows:
+### Ctrl+Shift+Esc, like in Windows
+To start (or raise — pex is single-instance, a second launch raises the existing window) the same way as in Windows, bind a GNOME custom shortcut:
 ```bash
 gsettings set org.gnome.settings-daemon.plugins.media-keys custom-keybindings "['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/pex/']"
 dconf write /org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/pex/name "'PEX'"
-dconf write /org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/pex/command "'$HOME/projects/pex/pex.cpp/build/pex'"
+dconf write /org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/pex/command "'{path-to-executable-location}/pex'"
 dconf write /org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/pex/binding "'<Control><Shift>Escape'"
 ```
 
+## Memory footprint
+Most of the GUI's RSS (~150 MB) is the OpenGL/Wayland rendering stack, not pex itself (see issue #5 for measurements). If memory matters:
+* use `pexc` (~5 MB), or
+* run the GUI under XWayland: `WAYLAND_DISPLAY= ./pex` (saves ~50 MB by skipping libdecor/GTK client-side decorations)

--- a/src/core/model/process_info.hpp
+++ b/src/core/model/process_info.hpp
@@ -25,6 +25,7 @@ struct ProcessInfo {
     std::string executable_path;
     char state_char = '?';
     std::string user_name;
+    bool is_kernel_thread = false;  // Linux: PF_KTHREAD, FreeBSD: P_KPROC, Solaris: SSYS
 
     // CPU usage (calculated by DataStore)
     double cpu_percent = 0.0;        // Per-core (100% = 1 core)

--- a/src/core/services/settings.cpp
+++ b/src/core/services/settings.cpp
@@ -1,0 +1,72 @@
+#include "settings.hpp"
+
+#include <charconv>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+
+namespace fs = std::filesystem;
+
+namespace pex {
+
+Settings::Settings() {
+    if (const char* xdg = std::getenv("XDG_CONFIG_HOME"); xdg && *xdg) {
+        path_ = std::string(xdg) + "/pex/pex.conf";
+    } else if (const char* home = std::getenv("HOME"); home && *home) {
+        path_ = std::string(home) + "/.config/pex/pex.conf";
+    } else {
+        path_ = "pex.conf";  // Last resort: current directory
+    }
+}
+
+void Settings::load() {
+    std::ifstream file(path_);
+    if (!file) return;
+
+    std::string line;
+    while (std::getline(file, line)) {
+        if (line.empty() || line[0] == '#') continue;
+        const size_t eq = line.find('=');
+        if (eq == std::string::npos || eq == 0) continue;
+        values_[line.substr(0, eq)] = line.substr(eq + 1);
+    }
+}
+
+bool Settings::save() const {
+    std::error_code ec;
+    fs::create_directories(fs::path(path_).parent_path(), ec);
+
+    std::ofstream file(path_);
+    if (!file) return false;
+
+    file << "# pex settings - edited by pex/pexc on exit\n";
+    for (const auto& [key, value] : values_) {
+        file << key << '=' << value << '\n';
+    }
+    return file.good();
+}
+
+int Settings::get_int(const std::string& key, const int def) const {
+    const auto it = values_.find(key);
+    if (it == values_.end()) return def;
+    int value = def;
+    const auto& s = it->second;
+    std::from_chars(s.data(), s.data() + s.size(), value);
+    return value;
+}
+
+bool Settings::get_bool(const std::string& key, const bool def) const {
+    const auto it = values_.find(key);
+    if (it == values_.end()) return def;
+    return it->second == "1" || it->second == "true";
+}
+
+void Settings::set_int(const std::string& key, const int value) {
+    values_[key] = std::to_string(value);
+}
+
+void Settings::set_bool(const std::string& key, const bool value) {
+    values_[key] = value ? "1" : "0";
+}
+
+} // namespace pex

--- a/src/core/services/settings.hpp
+++ b/src/core/services/settings.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <map>
+#include <string>
+
+namespace pex {
+
+// Minimal key=value settings persistence (issue #1).
+// File: $XDG_CONFIG_HOME/pex/pex.conf (or ~/.config/pex/pex.conf).
+// The whole file is loaded into a map and written back on save, so unknown
+// keys are preserved - the GUI and TUI can share one file without clobbering
+// each other's settings. (Per-window/table layout of the GUI is persisted
+// separately by Dear ImGui in imgui.ini.)
+class Settings {
+public:
+    Settings();  // Resolves the path; call load() to read the file
+
+    void load();
+    bool save() const;  // Creates the config directory if needed
+
+    [[nodiscard]] int get_int(const std::string& key, int def) const;
+    [[nodiscard]] bool get_bool(const std::string& key, bool def) const;
+    void set_int(const std::string& key, int value);
+    void set_bool(const std::string& key, bool value);
+
+    [[nodiscard]] const std::string& path() const { return path_; }
+
+private:
+    std::string path_;
+    std::map<std::string, std::string> values_;
+};
+
+} // namespace pex

--- a/src/platform/freebsd/freebsd_process_data_provider.cpp
+++ b/src/platform/freebsd/freebsd_process_data_provider.cpp
@@ -131,6 +131,7 @@ std::vector<ProcessInfo> FreeBSDProcessDataProvider::get_all_processes(int64_t t
         info.parent_pid = kp[i].ki_ppid;
         info.name = kp[i].ki_comm;
         info.state_char = map_state(kp[i].ki_stat);
+        info.is_kernel_thread = (kp[i].ki_flag & P_KPROC) != 0;
         info.user_name = get_username(kp[i].ki_uid);
         info.executable_path = get_executable_path(info.pid);
         info.priority = kp[i].ki_pri.pri_level;
@@ -206,6 +207,7 @@ std::optional<ProcessInfo> FreeBSDProcessDataProvider::get_process_info(int pid,
     info.parent_pid = kp.ki_ppid;
     info.name = kp.ki_comm;
     info.state_char = map_state(kp.ki_stat);
+    info.is_kernel_thread = (kp.ki_flag & P_KPROC) != 0;
     info.user_name = get_username(kp.ki_uid);
     info.executable_path = get_executable_path(pid);
     info.priority = kp.ki_pri.pri_level;

--- a/src/platform/linux/procfs/procfs_processes.cpp
+++ b/src/platform/linux/procfs/procfs_processes.cpp
@@ -98,6 +98,8 @@ std::optional<ProcessInfo> ProcfsReader::get_process_info(int pid, int64_t total
     info.kernel_time = stime;
     info.priority = static_cast<int>(priority);
     info.thread_count = static_cast<int>(num_threads);
+    constexpr unsigned int kPfKthread = 0x00200000;  // PF_KTHREAD from linux/sched.h
+    info.is_kernel_thread = (flags & kPfKthread) != 0;
 
     auto& sys = SystemInfo::instance();
     uint64_t boot_time = sys.get_boot_time_ticks();

--- a/src/platform/solaris/solaris_process_data_provider.cpp
+++ b/src/platform/solaris/solaris_process_data_provider.cpp
@@ -1,6 +1,7 @@
 #include "solaris_process_data_provider.hpp"
 
 #include <sys/types.h>
+#include <sys/proc.h>  // SSYS flag
 #include <procfs.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -93,6 +94,7 @@ std::optional<ProcessInfo> SolarisProcessDataProvider::read_process_info(int pid
     info.parent_pid = psinfo.pr_ppid;
     info.name = psinfo.pr_fname;
     info.state_char = map_state(psinfo.pr_lwp.pr_sname);
+    info.is_kernel_thread = (psinfo.pr_flag & SSYS) != 0;  // System process (sched, pageout, ...)
     info.user_name = get_username(psinfo.pr_uid);
     info.priority = psinfo.pr_lwp.pr_pri;  // Dynamic priority, consistent with other platforms
     info.thread_count = psinfo.pr_nlwp;

--- a/src/platform/solaris/solaris_process_data_provider.cpp
+++ b/src/platform/solaris/solaris_process_data_provider.cpp
@@ -1,7 +1,6 @@
 #include "solaris_process_data_provider.hpp"
 
 #include <sys/types.h>
-#include <sys/proc.h>  // SSYS flag
 #include <procfs.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -94,7 +93,11 @@ std::optional<ProcessInfo> SolarisProcessDataProvider::read_process_info(int pid
     info.parent_pid = psinfo.pr_ppid;
     info.name = psinfo.pr_fname;
     info.state_char = map_state(psinfo.pr_lwp.pr_sname);
-    info.is_kernel_thread = (psinfo.pr_flag & SSYS) != 0;  // System process (sched, pageout, ...)
+    // SSYS from <sys/proc.h>: system process (sched, pageout, fsflush, ...).
+    // The constant is used directly because including <sys/proc.h> clashes
+    // with the std::filesystem namespace alias in this file.
+    constexpr int kSsysFlag = 0x00000001;
+    info.is_kernel_thread = (psinfo.pr_flag & kSsysFlag) != 0;
     info.user_name = get_username(psinfo.pr_uid);
     info.priority = psinfo.pr_lwp.pr_pri;  // Dynamic priority, consistent with other platforms
     info.thread_count = psinfo.pr_nlwp;

--- a/src/ui/common/viewmodels/process_list_view_model.hpp
+++ b/src/ui/common/viewmodels/process_list_view_model.hpp
@@ -16,6 +16,7 @@ struct ProcessListViewModel {
 
     // Tree view state
     bool is_tree_view = true;
+    bool show_kernel_threads = true;
     std::set<int> collapsed_pids;  // Track which nodes are collapsed
 
     // Sorting state (for list view)

--- a/src/ui/imgui/imgui_app.cpp
+++ b/src/ui/imgui/imgui_app.cpp
@@ -51,6 +51,16 @@ ImGuiApp::~ImGuiApp() {
 }
 
 void ImGuiApp::run() {
+    // Load persisted settings (issue #1)
+    settings_.load();
+    const int win_w = std::clamp(settings_.get_int("gui.window_width", 1400), 400, 10000);
+    const int win_h = std::clamp(settings_.get_int("gui.window_height", 900), 300, 10000);
+    data_store_->set_refresh_interval(
+        std::clamp(settings_.get_int("refresh_interval_ms", 1000), 100, 60000));
+    view_model_.process_list.is_tree_view = settings_.get_bool("gui.tree_view", true);
+    view_model_.process_list.show_kernel_threads = settings_.get_bool("show_kernel_threads", true);
+    view_model_.system_panel.is_visible = settings_.get_bool("gui.system_panel", true);
+
     // Initialize GLFW
     glfwSetErrorCallback([](int code, const char* desc) {
         std::fprintf(stderr, "GLFW error %d: %s\n", code, desc ? desc : "(null)");
@@ -71,7 +81,7 @@ void ImGuiApp::run() {
     const std::string window_title = "PEX: " + system_provider_->get_system_info_string();
 
     // Create window
-    window_ = glfwCreateWindow(1400, 900, window_title.c_str(), nullptr, nullptr);
+    window_ = glfwCreateWindow(win_w, win_h, window_title.c_str(), nullptr, nullptr);
     if (!window_) {
         glfwTerminate();
         throw std::runtime_error("Failed to create GLFW window");
@@ -167,6 +177,21 @@ void ImGuiApp::run() {
         ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 
         glfwSwapBuffers(window_);
+    }
+
+    // Persist settings (issue #1) - window size must be read before destroy
+    {
+        int w = 0, h = 0;
+        glfwGetWindowSize(window_, &w, &h);
+        if (w > 0 && h > 0) {
+            settings_.set_int("gui.window_width", w);
+            settings_.set_int("gui.window_height", h);
+        }
+        settings_.set_int("refresh_interval_ms", data_store_->get_refresh_interval());
+        settings_.set_bool("gui.tree_view", view_model_.process_list.is_tree_view);
+        settings_.set_bool("show_kernel_threads", view_model_.process_list.show_kernel_threads);
+        settings_.set_bool("gui.system_panel", view_model_.system_panel.is_visible);
+        settings_.save();
     }
 
     // Stop background threads (find worker first: it posts GLFW events)

--- a/src/ui/imgui/imgui_app.hpp
+++ b/src/ui/imgui/imgui_app.hpp
@@ -7,6 +7,7 @@
 #include "../../core/services/history_store.hpp"
 #include "../common/viewmodels/app_view_model.hpp"
 #include "../../core/services/name_resolver.hpp"
+#include "../../core/services/settings.hpp"
 #include <memory>
 #include <atomic>
 #include <mutex>
@@ -62,7 +63,8 @@ private:
 
     void handle_keyboard_navigation();
     [[nodiscard]] std::vector<ProcessNode*> get_visible_items() const;
-    static void collect_visible_items(ProcessNode* node, std::vector<ProcessNode*>& items);
+    static void collect_visible_items(ProcessNode* node, std::vector<ProcessNode*>& items,
+                                      bool show_kernel_threads);
 
     void search_select_first();
     void search_next();
@@ -121,6 +123,9 @@ private:
 
     // Name resolver for DNS and service lookups
     NameResolver name_resolver_;
+
+    // Persistent settings (issue #1) - loaded/saved in run()
+    Settings settings_;
 
     // Event debouncing
     void post_empty_event_debounced();

--- a/src/ui/imgui/imgui_app_menus.cpp
+++ b/src/ui/imgui/imgui_app_menus.cpp
@@ -27,6 +27,7 @@ void ImGuiApp::render_menu_bar() {
             if (ImGui::MenuItem("History - Top Consumers...", nullptr, false, history_ != nullptr)) {
                 history_view_visible_ = true;
             }
+            ImGui::MenuItem("Show Kernel Threads", nullptr, &view_model_.process_list.show_kernel_threads);
             ImGui::Separator();
             if (ImGui::MenuItem("Refresh Now", "F5")) {
                 details_force_refresh_ = true;

--- a/src/ui/imgui/imgui_input.cpp
+++ b/src/ui/imgui/imgui_input.cpp
@@ -23,11 +23,13 @@ bool matches_search_term(const ProcessInfo& info, const std::string& search_lowe
 
 } // namespace
 
-void ImGuiApp::collect_visible_items(ProcessNode* node, std::vector<ProcessNode*>& items) {
+void ImGuiApp::collect_visible_items(ProcessNode* node, std::vector<ProcessNode*>& items,
+                                     const bool show_kernel_threads) {
+    if (!show_kernel_threads && node->info.is_kernel_thread) return;
     items.push_back(node);
     if (node->is_expanded) {
         for (auto& child : node->children) {
-            collect_visible_items(child.get(), items);
+            collect_visible_items(child.get(), items, show_kernel_threads);
         }
     }
 }
@@ -36,13 +38,15 @@ std::vector<ProcessNode*> ImGuiApp::get_visible_items() const {
     std::vector<ProcessNode*> items;
     if (!current_data_) return items;
 
+    const bool show_kernel = view_model_.process_list.show_kernel_threads;
     if (view_model_.process_list.is_tree_view) {
         for (auto& root : current_data_->process_tree) {
-            collect_visible_items(root.get(), items);
+            collect_visible_items(root.get(), items, show_kernel);
         }
     } else {
         std::function<void(ProcessNode*)> flatten;
         flatten = [&](ProcessNode* node) {
+            if (!show_kernel && node->info.is_kernel_thread) return;
             items.push_back(node);
             for (auto& child : node->children) {
                 flatten(child.get());
@@ -132,8 +136,11 @@ std::vector<ProcessNode*> ImGuiApp::find_matching_processes() const {
     const std::string search_lower = to_lower_copy(pl.search_buffer);
 
     // Search ALL processes (depth-first), regardless of expansion state,
-    // so matches under collapsed parents can still be found.
+    // so matches under collapsed parents can still be found. Hidden kernel
+    // threads are excluded so search cannot land on an invisible row.
+    const bool show_kernel = view_model_.process_list.show_kernel_threads;
     std::function<void(ProcessNode*)> visit = [&](ProcessNode* node) {
+        if (!show_kernel && node->info.is_kernel_thread) return;
         if (matches_search_term(node->info, search_lower)) {
             matches.push_back(node);
         }

--- a/src/ui/imgui/imgui_process_list_view.cpp
+++ b/src/ui/imgui/imgui_process_list_view.cpp
@@ -97,6 +97,9 @@ void ImGuiApp::render_process_tree() {
 }
 
 void ImGuiApp::render_process_tree_node(ProcessNode& node, const int depth) {
+    // Kernel threads hidden: skip the node and its (kernel) subtree
+    if (!view_model_.process_list.show_kernel_threads && node.info.is_kernel_thread) return;
+
     ImGui::PushID(node.info.pid);
     ImGui::TableNextRow();
 
@@ -245,9 +248,11 @@ void ImGuiApp::render_process_list() {
         show_column_tooltips();
 
         // Flatten tree for list view
+        const bool show_kernel = view_model_.process_list.show_kernel_threads;
         std::vector<ProcessNode*> flat_list;
         std::function<void(ProcessNode*)> flatten;
         flatten = [&](ProcessNode* node) {
+            if (!show_kernel && node->info.is_kernel_thread) return;
             flat_list.push_back(node);
             for (auto& child : node->children) {
                 flatten(child.get());

--- a/src/ui/tui/tui_app.cpp
+++ b/src/ui/tui/tui_app.cpp
@@ -39,6 +39,12 @@ TuiApp::~TuiApp() {
 }
 
 void TuiApp::run() {
+    // Load persisted settings (issue #1)
+    settings_.load();
+    view_model_.process_list.show_kernel_threads = settings_.get_bool("show_kernel_threads", true);
+    view_model_.system_panel.is_visible = settings_.get_bool("tui.system_panel", true);
+    system_panel_expanded_ = settings_.get_bool("tui.system_panel_expanded", false);
+
     // Initialize ncurses
     if (!initscr()) {
         fprintf(stderr, "pexc: initscr() failed\n");
@@ -150,6 +156,12 @@ void TuiApp::run() {
             needs_render = false;
         }
     }
+
+    // Persist settings (issue #1)
+    settings_.set_bool("show_kernel_threads", view_model_.process_list.show_kernel_threads);
+    settings_.set_bool("tui.system_panel", view_model_.system_panel.is_visible);
+    settings_.set_bool("tui.system_panel_expanded", system_panel_expanded_);
+    settings_.save();
 
     // Cleanup
     stop_find_scan();

--- a/src/ui/tui/tui_app.hpp
+++ b/src/ui/tui/tui_app.hpp
@@ -5,6 +5,7 @@
 #include "../../platform/interfaces/i_process_killer.hpp"
 #include "../../core/services/data_store.hpp"
 #include "../../core/services/name_resolver.hpp"
+#include "../../core/services/settings.hpp"
 #include "../common/viewmodels/app_view_model.hpp"
 #include <chrono>
 #include <memory>
@@ -82,7 +83,7 @@ private:
     // Navigation helpers
     [[nodiscard]] std::vector<ProcessNode*> get_visible_items() const;
     static void collect_visible_items(ProcessNode* node, std::vector<ProcessNode*>& items,
-                                      const std::set<int>& collapsed);
+                                      const std::set<int>& collapsed, bool show_kernel_threads);
     void move_selection(int delta);
     void page_up();
     void page_down();
@@ -136,6 +137,9 @@ private:
 
     // Name resolver for DNS lookups in network tab
     mutable NameResolver name_resolver_;
+
+    // Persistent settings (issue #1) - loaded/saved in run()
+    Settings settings_;
 
     // ncurses windows
     WINDOW* main_win_ = nullptr;

--- a/src/ui/tui/tui_app_navigation.cpp
+++ b/src/ui/tui/tui_app_navigation.cpp
@@ -9,20 +9,23 @@ std::vector<ProcessNode*> TuiApp::get_visible_items() const {
     if (!current_data_) return items;
 
     for (const auto& root : current_data_->process_tree) {
-        collect_visible_items(root.get(), items, view_model_.process_list.collapsed_pids);
+        collect_visible_items(root.get(), items, view_model_.process_list.collapsed_pids,
+                              view_model_.process_list.show_kernel_threads);
     }
     return items;
 }
 
 void TuiApp::collect_visible_items(ProcessNode* node, std::vector<ProcessNode*>& items,
-                                   const std::set<int>& collapsed) {
+                                   const std::set<int>& collapsed,
+                                   const bool show_kernel_threads) {
     if (!node) return;
+    if (!show_kernel_threads && node->info.is_kernel_thread) return;
 
     items.push_back(node);
 
     if (const bool is_collapsed = collapsed.contains(node->info.pid); !is_collapsed) {
         for (const auto& child : node->children) {
-            collect_visible_items(child.get(), items, collapsed);
+            collect_visible_items(child.get(), items, collapsed, show_kernel_threads);
         }
     }
 }
@@ -103,8 +106,11 @@ std::vector<ProcessNode*> TuiApp::find_matching_processes() const {
     if (!current_data_) return matches;
 
     // Search ALL processes (depth-first), regardless of collapsed state,
-    // so matches under collapsed parents can still be found.
+    // so matches under collapsed parents can still be found. Hidden kernel
+    // threads are excluded so search cannot land on an invisible row.
+    const bool show_kernel = view_model_.process_list.show_kernel_threads;
     std::function<void(ProcessNode*)> visit = [&](ProcessNode* node) {
+        if (!show_kernel && node->info.is_kernel_thread) return;
         if (matches_search(node->info)) {
             matches.push_back(node);
         }

--- a/src/ui/tui/tui_input.cpp
+++ b/src/ui/tui/tui_input.cpp
@@ -93,6 +93,11 @@ void TuiApp::handle_input(int ch) {
             export_history();
             return;
 
+        case 'u':  // Show/hide kernel threads (issue #2)
+            view_model_.process_list.show_kernel_threads =
+                !view_model_.process_list.show_kernel_threads;
+            return;
+
         case 'n':  // Next search match
             if (!view_model_.process_list.search_text.empty()) {
                 search_next();

--- a/src/ui/tui/tui_kill_dialog.cpp
+++ b/src/ui/tui/tui_kill_dialog.cpp
@@ -137,6 +137,7 @@ void TuiApp::render_help_overlay() {
         "  n/N             Next/previous search match",
         "  o               Find open file/handle",
         "  d               Dump history to CSV (~/pex-history-*)",
+        "  u               Show/hide kernel threads",
         "  x               Kill process",
         "  K               Kill process tree",
         "  r/F5            Force refresh",


### PR DESCRIPTION
## README refresh
Full Features section (I/O columns, history + Top Consumers + CSV export, find-open-file, single-instance raise), GUI and TUI key tables, TUI-only build flag, Solaris system-ncurses recipe, memory-footprint guidance (#5 analysis), Ctrl+Shift+Esc GNOME binding (#3).

## Issue #2 — show/hide kernel threads
- `ProcessInfo.is_kernel_thread` set per platform: Linux stat-flags `PF_KTHREAD` (no cmdline heuristics, zombies not misclassified), FreeBSD `P_KPROC`, Solaris `SSYS`
- GUI: View → Show Kernel Threads; TUI: `u` key
- Hidden kernel subtrees skipped in rendering, keyboard navigation and search in both UIs

## Issue #1 — persist UI layout/settings
- New `Settings` core service: key=value file at `~/.config/pex/pex.conf` (XDG-aware); whole file loaded and rewritten, so GUI and TUI share it without clobbering each other's keys
- GUI persists window size, refresh interval, tree/list mode, system panel, kernel toggle (window/table layout already persisted via `imgui.ini`)
- TUI persists system panel state and kernel toggle

## PRIVILEGES.md (new, linked from README)
Recipe-style per-OS guide for elevated permissions: Linux setcap (plain + group-restricted), Solaris RBAC profile + pfexec (complete recipe incl. the `exec_attr` lines the old README snippet was missing) + per-user defaultpriv, FreeBSD sudo/doas with X11 caveats, and setuid documented as the discouraged nuclear alternative.

## Verification
- Zero-warning builds on Linux (WSL) and **real Solaris 11.4 hardware** (incl. a fix for the `<sys/proc.h>`/`fs`-alias clash, SSYS value verified against the system header)
- Settings round-trip tested on both: toggle → quit → `pex.conf` written → next run loads it
- Multi-platform CI green (Ubuntu, Debian, FreeBSD, Solaris)

Closes #1
Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)